### PR TITLE
Add NewCodes endpoint with tests

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/supranational/blst v0.3.13 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
@@ -47,5 +48,7 @@ require (
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gorm.io/driver/sqlite v1.5.7 // indirect
+	gorm.io/gorm v1.25.12 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )

--- a/backend/router/router.go
+++ b/backend/router/router.go
@@ -20,14 +20,18 @@ func New(s *handlers.BotService, a *handlers.AccountService) *chi.Mux {
 		MaxAge:           300,
 	}))
 
-	r.Post("/events", s.NewEvent)
-	r.Post("/events/{id}/codes", s.NewCodes)
-	r.Get("/events", s.GetCodes)
-
-	r.Post("/redeem", s.Redeem)
+	AddBotRoutes(r, s)
 
 	r.Post("/account", a.AddAccount)
 	r.Get("/account", a.GetAccount)
 
 	return r
+}
+
+func AddBotRoutes(r *chi.Mux, s *handlers.BotService) {
+	r.Post("/events", s.NewEvent)
+	r.Post("/events/{event_id}/codes", s.NewCodesRequest)
+	r.Get("/events", s.GetCodesRequest)
+
+	r.Post("/redeem", s.Redeem)
 }

--- a/backend/router/router.go
+++ b/backend/router/router.go
@@ -21,6 +21,7 @@ func New(s *handlers.BotService, a *handlers.AccountService) *chi.Mux {
 	}))
 
 	r.Post("/events", s.NewEvent)
+	r.Post("/events/{id}/codes", s.NewCodes)
 	r.Get("/events", s.GetCodes)
 
 	r.Post("/redeem", s.Redeem)

--- a/backend/structs/db.go
+++ b/backend/structs/db.go
@@ -25,3 +25,8 @@ type RedeemRequest struct {
 	Code    string `json:"code"`
 	Address string `json:"address"`
 }
+
+type NewCodesRequest struct {
+	Event string `json:"event"`
+	Count uint32 `json:"count"`
+}

--- a/backend/test/botservice_test.go
+++ b/backend/test/botservice_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/faucet-portal/backend/db"
+	"github.com/faucet-portal/backend/handlers"
+	"github.com/faucet-portal/backend/structs"
+	"github.com/stretchr/testify/assert"
+)
+
+func MakeBotService() *handlers.BotService {
+	bdb := db.InitDB("bot")
+	botDb := db.Bot(bdb)
+	botDb.CreateTables()
+	return handlers.NewBotService(botDb, nil)
+}
+
+func TestBotServiceLogin(t *testing.T) {
+	t.Setenv("ADMIN_KEY", "0123456789")
+
+	bot_service := MakeBotService()
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	req.Header.Set("X-API-KEY", "abcdefghijklmnop")
+	w := httptest.NewRecorder()
+	bot_service.GetCodes(w, req)
+	res := w.Result()
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected status code 401 got %v", res.StatusCode)
+	}
+}
+
+func TestBotServiceNewCodes(t *testing.T) {
+	t.Setenv("DB_FOLDER_PATH", "./test_data")
+	t.Setenv("ADMIN_KEY", "0123456789")
+
+	bot_service := MakeBotService()
+	post_body := map[string]interface{}{
+		"Event": "EVENT1",
+		"Count": 10,
+	}
+	body, _ := json.Marshal(post_body)
+	req := httptest.NewRequest(http.MethodPost, "/events/abcdef/codes", bytes.NewReader(body))
+	req.Header.Set("X-API-KEY", "0123456789")
+	w := httptest.NewRecorder()
+	bot_service.NewCodes(w, req)
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("expected status code 200 got %v", res.StatusCode)
+	}
+	var response []structs.Code
+	err = json.Unmarshal(data, &response)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+	assert.Equal(t, len(response), 10)
+}

--- a/backend/test/botservice_test.go
+++ b/backend/test/botservice_test.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/faucet-portal/backend/db"
 	"github.com/faucet-portal/backend/handlers"
+	"github.com/faucet-portal/backend/router"
 	"github.com/faucet-portal/backend/structs"
+	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,13 +25,14 @@ func MakeBotService() *handlers.BotService {
 }
 
 func TestBotServiceLogin(t *testing.T) {
+
 	t.Setenv("ADMIN_KEY", "0123456789")
 
 	bot_service := MakeBotService()
 	req := httptest.NewRequest(http.MethodGet, "/events", nil)
 	req.Header.Set("X-API-KEY", "abcdefghijklmnop")
 	w := httptest.NewRecorder()
-	bot_service.GetCodes(w, req)
+	bot_service.GetCodesRequest(w, req)
 	res := w.Result()
 	if res.StatusCode != http.StatusUnauthorized {
 		t.Errorf("expected status code 401 got %v", res.StatusCode)
@@ -40,16 +43,28 @@ func TestBotServiceNewCodes(t *testing.T) {
 	t.Setenv("DB_FOLDER_PATH", "./test_data")
 	t.Setenv("ADMIN_KEY", "0123456789")
 
+	r := chi.NewRouter()
+
 	bot_service := MakeBotService()
+
+	router.AddBotRoutes(r, bot_service)
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
 	post_body := map[string]interface{}{
-		"Event": "EVENT1",
 		"Count": 10,
 	}
 	body, _ := json.Marshal(post_body)
 	req := httptest.NewRequest(http.MethodPost, "/events/abcdef/codes", bytes.NewReader(body))
 	req.Header.Set("X-API-KEY", "0123456789")
 	w := httptest.NewRecorder()
-	bot_service.NewCodes(w, req)
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+		return
+	}
+	defer resp.Body.Close()
 	res := w.Result()
 	defer res.Body.Close()
 	data, err := io.ReadAll(res.Body)
@@ -64,5 +79,14 @@ func TestBotServiceNewCodes(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected error to be nil got %v", err)
 	}
-	assert.Equal(t, len(response), 10)
+	// Check if the codes are in the database
+	codes, err := bot_service.GetCodes("abcdef", 10, 0)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+	assert.Equal(t, len(codes), 10)
+	for _, code := range codes {
+		assert.Equal(t, code.Redeemed, false)
+		assert.Equal(t, code.Event, "abcdef")
+	}
 }


### PR DESCRIPTION
This PR adds an authenticated endpoint NewCodes which will add a batch of new codes. This code is just a start it could use a few improvements:

1. Doesn't currently check that the event already exists but it should
2. It used Guids for codes which are long and hard to type in. Codes should be shorter