### PR TITLE
Support live mobile wallet backend flows

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -26,6 +26,14 @@ func main() {
 	}
 	defer appLogger.Close()
 
+	if err := bootstrap.InitializeDatabases(ctx, pools, appLogger); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := bootstrap.RunInitializationSyncs(ctx, pools, appLogger); err != nil {
+		log.Fatal(err)
+	}
+
 	handler, err := bootstrap.NewServerHandler(ctx, pools, appLogger)
 	if err != nil {
 		log.Fatal(err)

--- a/backend/db/app_location.go
+++ b/backend/db/app_location.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/SFLuv/app/backend/structs"
@@ -11,34 +12,63 @@ import (
 func (a *AppDB) GetLocation(ctx context.Context, id uint64) (*structs.PublicLocation, error) {
 	row := a.db.QueryRow(ctx, `
 		SELECT
-			id,
-			google_id,
-			name,
-			approval,
-			description,
-			type,
-			street,
-			city,
-			state,
-			zip,
-			lat,
-			lng,
-			phone,
-			email,
-			website,
-			image_url,
-			rating,
-			maps_page
-		FROM locations
-		WHERE id = $1;
+			l.id,
+			l.google_id,
+			l.name,
+			l.approval,
+			COALESCE(
+				NULLIF(TRIM(u.primary_wallet_address), ''),
+				NULLIF(TRIM(legacy_wallet.smart_address), ''),
+				''
+			) AS pay_to_address,
+			l.description,
+			l.type,
+			l.street,
+			l.city,
+			l.state,
+			l.zip,
+			l.lat,
+			l.lng,
+			l.phone,
+			l.email,
+			l.website,
+			l.image_url,
+			l.rating,
+			l.maps_page
+		FROM locations l
+		LEFT JOIN users u
+			ON u.id = l.owner_id
+		LEFT JOIN LATERAL (
+			SELECT
+				w.smart_address
+			FROM
+				wallets w
+			WHERE
+				w.owner = l.owner_id
+			AND
+				w.is_eoa = FALSE
+			AND
+				w.smart_index = 0
+			AND
+				w.smart_address IS NOT NULL
+			AND
+				TRIM(w.smart_address) <> ''
+			ORDER BY
+				w.id ASC
+			LIMIT 1
+		) legacy_wallet
+			ON TRUE
+		WHERE l.id = $1;
 	`, id)
 
 	location := structs.PublicLocation{}
+	var payToAddress sql.NullString
 	err := row.Scan(
 		&location.ID,
 		&location.GoogleID,
 		&location.Name,
 		&location.Approval,
+		&payToAddress,
 		&location.Description,
 		&location.Type,
 		&location.Street,
@@ -56,6 +86,9 @@ func (a *AppDB) GetLocation(ctx context.Context, id uint64) (*structs.PublicLoca
 	)
 	if err != nil {
 		return nil, err
+	}
+	if payToAddress.Valid {
+		location.PayToAddress = payToAddress.String
 	}
 
 	rows, err := a.db.Query(ctx, `
@@ -91,26 +124,53 @@ func (s *AppDB) GetLocations(ctx context.Context, r *structs.LocationsPageReques
 
 	rows, err := s.db.Query(ctx, `
 		SELECT
-			id,
-			google_id,
-			name,
-			description,
-			type,
-			street,
-			city,
-			state,
-			zip,
-			lat,
-			lng,
-			phone,
-			email,
-			website,
-			image_url,
-			rating,
-			maps_page
-		FROM locations
-		WHERE approval = TRUE
-		ORDER BY id
+			l.id,
+			l.google_id,
+			l.name,
+			COALESCE(
+				NULLIF(TRIM(u.primary_wallet_address), ''),
+				NULLIF(TRIM(legacy_wallet.smart_address), ''),
+				''
+			) AS pay_to_address,
+			l.description,
+			l.type,
+			l.street,
+			l.city,
+			l.state,
+			l.zip,
+			l.lat,
+			l.lng,
+			l.phone,
+			l.email,
+			l.website,
+			l.image_url,
+			l.rating,
+			l.maps_page
+		FROM locations l
+		LEFT JOIN users u
+			ON u.id = l.owner_id
+		LEFT JOIN LATERAL (
+			SELECT
+				w.smart_address
+			FROM
+				wallets w
+			WHERE
+				w.owner = l.owner_id
+			AND
+				w.is_eoa = FALSE
+			AND
+				w.smart_index = 0
+			AND
+				w.smart_address IS NOT NULL
+			AND
+				TRIM(w.smart_address) <> ''
+			ORDER BY
+				w.id ASC
+			LIMIT 1
+		) legacy_wallet
+			ON TRUE
+		WHERE l.approval = TRUE
+		ORDER BY l.id
 		LIMIT $1
 		OFFSET $2;
 	`, r.Count, offset)
@@ -123,11 +183,13 @@ func (s *AppDB) GetLocations(ctx context.Context, r *structs.LocationsPageReques
 
 	for rows.Next() {
 		location := structs.PublicLocation{}
+		var payToAddress sql.NullString
 
 		err = rows.Scan(
 			&location.ID,
 			&location.GoogleID,
 			&location.Name,
+			&payToAddress,
 			&location.Description,
 			&location.Type,
 			&location.Street,
@@ -146,6 +208,9 @@ func (s *AppDB) GetLocations(ctx context.Context, r *structs.LocationsPageReques
 
 		if err != nil {
 			return nil, fmt.Errorf("error scanning location row: %w", err)
+		}
+		if payToAddress.Valid {
+			location.PayToAddress = payToAddress.String
 		}
 		locations = append(locations, &location)
 	}

--- a/backend/db/app_wallet.go
+++ b/backend/db/app_wallet.go
@@ -31,7 +31,9 @@ func (a *AppDB) AddWallet(ctx context.Context, wallet *structs.Wallet) (int, err
 			$7
 		)
 		ON CONFLICT (owner, is_eoa, eoa_address, smart_index)
-		DO NOTHING
+		DO UPDATE
+		SET
+			name = wallets.name
 		RETURNING id;
 	`,
 		wallet.Owner,

--- a/backend/handlers/app_wallet.go
+++ b/backend/handlers/app_wallet.go
@@ -57,9 +57,11 @@ func (a *AppService) AddWallet(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	// Ignore any client-supplied id for wallet creation; the DB owns identity here.
-	wallet.Id = nil
 	wallet.Owner = *userDid
+	if wallet.Id == nil {
+		id := 0
+		wallet.Id = &id
+	}
 
 	id, err := a.db.AddWallet(r.Context(), &wallet)
 	if err != nil {

--- a/backend/structs/app_location.go
+++ b/backend/structs/app_location.go
@@ -67,6 +67,7 @@ type PublicLocation struct {
 	GoogleID     string   `json:"google_id"`
 	Name         string   `json:"name"`
 	Approval     bool     `json:"approval"`
+	PayToAddress string   `json:"pay_to_address"`
 	Description  string   `json:"description"`
 	Type         string   `json:"type"`
 	Street       string   `json:"street"`


### PR DESCRIPTION
This PR allows users to log into the mobile app using existing privy accounts, and to send SFLUV directly to our registered merchants using the mobile app's map interface. it doesn't change how QR codes are generated, or add in any support for Universal Links which will be used in the future