### PR TITLE
[codex] Improve admin analytics panel

### DIFF
--- a/backend/bootstrap/runtime.go
+++ b/backend/bootstrap/runtime.go
@@ -253,5 +253,8 @@ func NewServerHandler(ctx context.Context, pools *DBPools, appLogger *logger.Log
 	StartDeletedAccountPurgeLoop(ctx, a, appLogger)
 
 	p := handlers.NewPonderService(ponderDb, appDb, botDb, appLogger)
+	if err := p.SyncCurrentAnalyticsWalletRoleHistory(ctx); err != nil {
+		appLogger.Logf("error syncing analytics wallet role history during startup: %s", err)
+	}
 	return router.New(s, a, p), nil
 }

--- a/backend/bootstrap/schema_migrations.go
+++ b/backend/bootstrap/schema_migrations.go
@@ -550,6 +550,50 @@ var schemaMigrations = []SchemaMigration{
 			return nil
 		},
 	},
+	{
+		Version:     "1.13",
+		Description: "add analytics wallet role history and user activity snapshots",
+		Apply: func(ctx context.Context, pools *DBPools, appLogger *logger.LogCloser) error {
+			if _, err := pools.App.Exec(ctx, `
+				CREATE TABLE IF NOT EXISTS analytics_wallet_role_history(
+					id BIGSERIAL PRIMARY KEY,
+					address TEXT NOT NULL,
+					role TEXT NOT NULL CHECK (role IN ('admin', 'merchant', 'faucet', 'zapper')),
+					chain_id BIGINT NOT NULL,
+					user_id TEXT,
+					location_id INTEGER,
+					source TEXT NOT NULL DEFAULT '',
+					started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+					ended_at TIMESTAMPTZ,
+					created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+					updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+				);
+
+				CREATE INDEX IF NOT EXISTS analytics_wallet_role_history_lookup_idx
+					ON analytics_wallet_role_history(LOWER(address), role, chain_id, started_at, ended_at);
+				CREATE UNIQUE INDEX IF NOT EXISTS analytics_wallet_role_history_active_idx
+					ON analytics_wallet_role_history(LOWER(address), role, chain_id, COALESCE(user_id, ''), COALESCE(location_id, 0), source)
+					WHERE ended_at IS NULL;
+
+				CREATE TABLE IF NOT EXISTS analytics_user_activity(
+					id BIGSERIAL PRIMARY KEY,
+					user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+					activity_date DATE NOT NULL,
+					platform TEXT NOT NULL DEFAULT 'web',
+					first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+					last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+					UNIQUE(user_id, activity_date, platform)
+				);
+
+				CREATE INDEX IF NOT EXISTS analytics_user_activity_date_idx
+					ON analytics_user_activity(activity_date, user_id);
+			`); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	},
 }
 
 type versionTarget struct {

--- a/backend/db/admin_analytics.go
+++ b/backend/db/admin_analytics.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/SFLuv/app/backend/structs"
 )
@@ -239,4 +240,227 @@ func (a *AppDB) GetAnalyticsWorkflowCosts(ctx context.Context) ([]*structs.Analy
 	}
 
 	return costs, nil
+}
+
+type AnalyticsWalletRoleCandidate struct {
+	Address    string
+	Role       string
+	ChainID    int64
+	UserID     string
+	LocationID int
+	Source     string
+}
+
+func (a *AppDB) SyncAnalyticsWalletRoleHistory(ctx context.Context, chainID int64, candidates []AnalyticsWalletRoleCandidate) error {
+	normalized := make([]AnalyticsWalletRoleCandidate, 0, len(candidates))
+	seen := make(map[string]struct{})
+	for _, candidate := range candidates {
+		address := strings.TrimSpace(strings.ToLower(candidate.Address))
+		role := strings.TrimSpace(strings.ToLower(candidate.Role))
+		if address == "" || role == "" || chainID == 0 {
+			continue
+		}
+		source := strings.TrimSpace(candidate.Source)
+		key := fmt.Sprintf("%s|%s|%d|%s|%d|%s", address, role, chainID, candidate.UserID, candidate.LocationID, source)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		candidate.Address = address
+		candidate.Role = role
+		candidate.ChainID = chainID
+		candidate.Source = source
+		normalized = append(normalized, candidate)
+	}
+
+	tx, err := a.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("error beginning analytics wallet role sync: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx, `
+		CREATE TEMP TABLE tmp_analytics_wallet_roles(
+			address TEXT NOT NULL,
+			role TEXT NOT NULL,
+			chain_id BIGINT NOT NULL,
+			user_id TEXT NOT NULL DEFAULT '',
+			location_id INTEGER NOT NULL DEFAULT 0,
+			source TEXT NOT NULL DEFAULT ''
+		) ON COMMIT DROP;
+	`); err != nil {
+		return fmt.Errorf("error creating analytics wallet role sync temp table: %w", err)
+	}
+
+	for _, candidate := range normalized {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO tmp_analytics_wallet_roles(address, role, chain_id, user_id, location_id, source)
+			VALUES($1, $2, $3, $4, $5, $6);
+		`, candidate.Address, candidate.Role, candidate.ChainID, candidate.UserID, candidate.LocationID, candidate.Source); err != nil {
+			return fmt.Errorf("error staging analytics wallet role %s %s: %w", candidate.Role, candidate.Address, err)
+		}
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE analytics_wallet_role_history h
+		SET
+			ended_at = NOW(),
+			updated_at = NOW()
+		WHERE
+			h.ended_at IS NULL
+		AND
+			(
+				h.chain_id <> $1
+				OR NOT EXISTS (
+					SELECT 1
+					FROM tmp_analytics_wallet_roles t
+					WHERE LOWER(h.address) = t.address
+					AND h.role = t.role
+					AND h.chain_id = t.chain_id
+					AND COALESCE(h.user_id, '') = t.user_id
+					AND COALESCE(h.location_id, 0) = t.location_id
+					AND h.source = t.source
+				)
+			);
+	`, chainID); err != nil {
+		return fmt.Errorf("error closing inactive analytics wallet role records: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO analytics_wallet_role_history(address, role, chain_id, user_id, location_id, source, started_at)
+		SELECT
+			t.address,
+			t.role,
+			t.chain_id,
+			NULLIF(t.user_id, ''),
+			NULLIF(t.location_id, 0),
+			t.source,
+			CASE
+				WHEN EXISTS (
+					SELECT 1
+					FROM analytics_wallet_role_history existing
+					WHERE LOWER(existing.address) = t.address
+					AND existing.role = t.role
+					AND existing.chain_id = t.chain_id
+					AND COALESCE(existing.user_id, '') = t.user_id
+					AND COALESCE(existing.location_id, 0) = t.location_id
+					AND existing.source = t.source
+				) THEN NOW()
+				ELSE TO_TIMESTAMP(0)
+			END
+		FROM
+			tmp_analytics_wallet_roles t
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM analytics_wallet_role_history h
+			WHERE h.ended_at IS NULL
+			AND LOWER(h.address) = t.address
+			AND h.role = t.role
+			AND h.chain_id = t.chain_id
+			AND COALESCE(h.user_id, '') = t.user_id
+			AND COALESCE(h.location_id, 0) = t.location_id
+			AND h.source = t.source
+		);
+	`); err != nil {
+		return fmt.Errorf("error inserting active analytics wallet role records: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("error committing analytics wallet role sync: %w", err)
+	}
+	return nil
+}
+
+func (a *AppDB) GetAnalyticsWalletRoleHistory(ctx context.Context) ([]*structs.AnalyticsWalletRoleRecord, error) {
+	rows, err := a.db.Query(ctx, `
+		SELECT
+			LOWER(address),
+			role,
+			chain_id,
+			COALESCE(user_id, ''),
+			COALESCE(location_id, 0),
+			EXTRACT(EPOCH FROM started_at)::bigint,
+			COALESCE(EXTRACT(EPOCH FROM ended_at)::bigint, 0)
+		FROM
+			analytics_wallet_role_history
+		ORDER BY
+			started_at ASC,
+			id ASC;
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("error querying analytics wallet role history: %w", err)
+	}
+	defer rows.Close()
+
+	records := make([]*structs.AnalyticsWalletRoleRecord, 0)
+	for rows.Next() {
+		var record structs.AnalyticsWalletRoleRecord
+		if err := rows.Scan(&record.Address, &record.Role, &record.ChainID, &record.UserID, &record.LocationID, &record.StartedAt, &record.EndedAt); err != nil {
+			return nil, fmt.Errorf("error scanning analytics wallet role history: %w", err)
+		}
+		records = append(records, &record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating analytics wallet role history: %w", err)
+	}
+	return records, nil
+}
+
+func (a *AppDB) RecordAnalyticsUserActivity(ctx context.Context, userID string, platform string, observedAt time.Time) error {
+	userID = strings.TrimSpace(userID)
+	platform = strings.TrimSpace(strings.ToLower(platform))
+	if userID == "" {
+		return nil
+	}
+	if platform == "" {
+		platform = "web"
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	}
+
+	_, err := a.db.Exec(ctx, `
+		INSERT INTO analytics_user_activity(user_id, activity_date, platform, first_seen_at, last_seen_at)
+		VALUES($1, $2, $3, $4, $4)
+		ON CONFLICT(user_id, activity_date, platform)
+		DO UPDATE SET
+			last_seen_at = GREATEST(analytics_user_activity.last_seen_at, EXCLUDED.last_seen_at);
+	`, userID, observedAt.UTC().Format("2006-01-02"), platform, observedAt.UTC())
+	if err != nil {
+		return fmt.Errorf("error recording analytics user activity: %w", err)
+	}
+	return nil
+}
+
+func (a *AppDB) GetAnalyticsUserActivity(ctx context.Context, start time.Time) (map[int64]map[string]struct{}, error) {
+	rows, err := a.db.Query(ctx, `
+		SELECT
+			EXTRACT(EPOCH FROM activity_date::timestamp)::bigint AS activity_day,
+			user_id
+		FROM
+			analytics_user_activity
+		WHERE
+			activity_date >= $1::date;
+	`, start.UTC().Format("2006-01-02"))
+	if err != nil {
+		return nil, fmt.Errorf("error querying analytics user activity: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[int64]map[string]struct{})
+	for rows.Next() {
+		var day int64
+		var userID string
+		if err := rows.Scan(&day, &userID); err != nil {
+			return nil, fmt.Errorf("error scanning analytics user activity: %w", err)
+		}
+		if result[day] == nil {
+			result[day] = make(map[string]struct{})
+		}
+		result[day][userID] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating analytics user activity: %w", err)
+	}
+	return result, nil
 }

--- a/backend/handlers/admin_analytics.go
+++ b/backend/handlers/admin_analytics.go
@@ -1,92 +1,78 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"math"
 	"math/big"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	appdb "github.com/SFLuv/app/backend/db"
 	"github.com/SFLuv/app/backend/structs"
 	"github.com/SFLuv/app/backend/utils"
 )
 
-type adminAnalyticsOwnerMeta struct {
-	UserID     string
-	IsAdmin    bool
-	IsMerchant bool
+const analyticsZeroAddress = "0x0000000000000000000000000000000000000000"
+
+type analyticsRoleSet map[string]struct{}
+
+type analyticsRoleIndex map[string][]*structs.AnalyticsWalletRoleRecord
+
+type analyticsPeriodBucket struct {
+	Key                string
+	Label              string
+	Unit               string
+	Start              time.Time
+	End                time.Time
+	AllTime            bool
+	ActiveUsers        map[string]struct{}
+	ActiveWallets      map[string]struct{}
+	Transactions       int
+	TransactionVolume  *big.Int
+	Rewards            *big.Int
+	RewardCount        int
+	Payments           *big.Int
+	PaymentPairs       map[string]map[string]int
+	Redemptions        *big.Int
+	UniqueVolunteers   map[string]struct{}
+	WeightedSpendSecs  *big.Int
+	WeightedSpendValue *big.Int
+	Events             int
 }
 
-type adminAnalyticsMonthBucket struct {
-	Key               string
-	Label             string
-	Start             time.Time
-	ActiveUsers       map[string]struct{}
-	TransactionVolume *big.Int
-	Distributed       *big.Int
-	MerchantSpend     *big.Int
-	MerchantCustomers map[string]int
-	VolunteerEvents   int
-	UniqueEarners     map[string]struct{}
-	ProjectCost       *big.Int
-	ProjectCount      int
+type analyticsPayment struct {
+	From      string
+	Timestamp uint64
 }
 
-type adminAnalyticsDayBucket struct {
-	Key         string
-	Label       string
-	ActiveUsers map[string]struct{}
+type analyticsReward struct {
+	To        string
+	Amount    *big.Int
+	Timestamp uint64
 }
 
 func (p *PonderService) GetAdminAnalyticsDashboard(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
-	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-	dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	chainID := analyticsChainID()
 
-	walletOwners, err := p.appDB.GetAnalyticsWalletOwners(r.Context())
-	if err != nil {
-		p.logger.Logf("error loading analytics wallet owners: %s", err)
+	if err := p.SyncAnalyticsWalletRoleHistory(r.Context(), chainID); err != nil {
+		p.logger.Logf("error syncing analytics wallet role history: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	merchantWallets, err := p.appDB.GetAnalyticsMerchantWallets(r.Context())
+	roleHistory, err := p.appDB.GetAnalyticsWalletRoleHistory(r.Context())
 	if err != nil {
-		p.logger.Logf("error loading analytics merchant wallets: %s", err)
+		p.logger.Logf("error loading analytics wallet role history: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-
-	totalActiveUsers, err := p.appDB.GetAnalyticsActiveUserCount(r.Context())
-	if err != nil {
-		p.logger.Logf("error loading analytics active user count: %s", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	workflowCosts, err := p.appDB.GetAnalyticsWorkflowCosts(r.Context())
-	if err != nil {
-		p.logger.Logf("error loading analytics workflow costs: %s", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	volunteerEvents, err := p.botDB.GetAnalyticsVolunteerEvents(r.Context())
-	if err != nil {
-		p.logger.Logf("error loading analytics volunteer events: %s", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	volunteerParticipation, err := p.botDB.GetAnalyticsVolunteerParticipationCounts(r.Context())
-	if err != nil {
-		p.logger.Logf("error loading analytics volunteer participation: %s", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
+	roles := buildAnalyticsRoleIndex(roleHistory, chainID)
 
 	transfers, err := p.db.GetAnalyticsTransfersSince(r.Context(), 0)
 	if err != nil {
@@ -95,105 +81,33 @@ func (p *PonderService) GetAdminAnalyticsDashboard(w http.ResponseWriter, r *htt
 		return
 	}
 
-	ownerByAddress := make(map[string]adminAnalyticsOwnerMeta, len(walletOwners))
-	registeredNonAdminAddresses := make([]string, 0, len(walletOwners))
-	for _, row := range walletOwners {
-		if row == nil {
-			continue
-		}
-		address := normalizeAnalyticsAddress(row.Address)
-		if address == "" {
-			continue
-		}
-		meta := adminAnalyticsOwnerMeta{
-			UserID:     row.UserID,
-			IsAdmin:    row.IsAdmin,
-			IsMerchant: row.IsMerchant,
-		}
-		ownerByAddress[address] = meta
-		if !row.IsAdmin {
-			registeredNonAdminAddresses = append(registeredNonAdminAddresses, address)
-		}
-	}
-
-	merchantByAddress := make(map[string]*structs.AnalyticsMerchantWallet, len(merchantWallets))
-	for _, wallet := range merchantWallets {
-		if wallet == nil {
-			continue
-		}
-		address := normalizeAnalyticsAddress(wallet.Address)
-		if address != "" {
-			merchantByAddress[address] = wallet
-		}
-	}
-
-	paidAddresses := utils.MergeAddressLists(
-		utils.ParseAddressList(os.Getenv("PAID_ADMIN_ADDRESSES")),
-		os.Getenv("ADMIN_ADDRESS"),
-		os.Getenv("BOT_ADDRESS"),
-		os.Getenv("NEXT_PUBLIC_FAUCET_ADDRESS"),
-	)
-	paidAddressSet := analyticsSetFromList(paidAddresses)
-
-	balances, err := p.db.GetAnalyticsAddressBalances(r.Context(), registeredNonAdminAddresses)
+	events, err := p.botDB.GetAnalyticsVolunteerEvents(r.Context())
 	if err != nil {
-		p.logger.Logf("error loading analytics balances: %s", err)
+		p.logger.Logf("error loading analytics bot events: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	registeredNonAdminBalance := big.NewInt(0)
-	for _, balance := range balances {
-		if balance == nil {
-			continue
-		}
-		amount := parseAnalyticsBigInt(balance.Balance)
-		if amount.Sign() > 0 {
-			registeredNonAdminBalance.Add(registeredNonAdminBalance, amount)
+	periods := analyticsReportingPeriods(now)
+	activity, err := p.appDB.GetAnalyticsUserActivity(r.Context(), time.Unix(0, 0).UTC())
+	if err != nil {
+		p.logger.Logf("error loading analytics user activity: %s", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	for day, users := range activity {
+		activityTime := time.Unix(day, 0).UTC()
+		for _, bucket := range periods {
+			if bucket.contains(activityTime) {
+				for userID := range users {
+					bucket.ActiveUsers[userID] = struct{}{}
+				}
+			}
 		}
 	}
 
-	monthlyOrder := make([]string, 0, 12)
-	monthly := make(map[string]*adminAnalyticsMonthBucket, 12)
-	for i := 11; i >= 0; i-- {
-		start := monthStart.AddDate(0, -i, 0)
-		key := start.Format("2006-01")
-		monthlyOrder = append(monthlyOrder, key)
-		monthly[key] = &adminAnalyticsMonthBucket{
-			Key:               key,
-			Label:             start.Format("Jan 2006"),
-			Start:             start,
-			ActiveUsers:       make(map[string]struct{}),
-			TransactionVolume: big.NewInt(0),
-			Distributed:       big.NewInt(0),
-			MerchantSpend:     big.NewInt(0),
-			MerchantCustomers: make(map[string]int),
-			UniqueEarners:     make(map[string]struct{}),
-			ProjectCost:       big.NewInt(0),
-		}
-	}
-
-	dailyOrder := make([]string, 0, 30)
-	daily := make(map[string]*adminAnalyticsDayBucket, 30)
-	for i := 29; i >= 0; i-- {
-		start := dayStart.AddDate(0, 0, -i)
-		key := start.Format("2006-01-02")
-		dailyOrder = append(dailyOrder, key)
-		daily[key] = &adminAnalyticsDayBucket{
-			Key:         key,
-			Label:       start.Format("Jan 2"),
-			ActiveUsers: make(map[string]struct{}),
-		}
-	}
-
-	totalDistributed := big.NewInt(0)
-	distributedSpentAtMerchants := big.NewInt(0)
-	merchantCustomers := make(map[string]int)
-	monthlyActiveNow := make(map[string]struct{})
-	monthlyActivePrevious := make(map[string]struct{})
-	dailyActiveNow := make(map[string]struct{})
-	outgoingByAddress := make(map[string][]*structs.AnalyticsTransfer)
-
+	paymentsBySender := make(map[string][]analyticsPayment)
+	rewards := make([]analyticsReward, 0)
 	for _, tx := range transfers {
 		if tx == nil {
 			continue
@@ -201,243 +115,333 @@ func (p *PonderService) GetAdminAnalyticsDashboard(w http.ResponseWriter, r *htt
 		from := normalizeAnalyticsAddress(tx.From)
 		to := normalizeAnalyticsAddress(tx.To)
 		amount := parseAnalyticsBigInt(tx.Amount)
-		if from == "" || to == "" || amount.Sign() <= 0 {
+		if from == "" || to == "" || amount.Sign() <= 0 || from == analyticsZeroAddress || to == analyticsZeroAddress {
 			continue
 		}
-
-		outgoingByAddress[from] = append(outgoingByAddress[from], tx)
 		txTime := time.Unix(int64(tx.Timestamp), 0).UTC()
+		fromRoles := roles.rolesAt(from, txTime)
+		toRoles := roles.rolesAt(to, txTime)
+		isReward := (fromRoles.has("admin") || fromRoles.has("faucet")) && toRoles.isUserWallet()
+		isPayment := fromRoles.isUserWallet() && toRoles.has("merchant")
+		isRedemption := fromRoles.has("merchant") && (toRoles.has("admin") || toRoles.has("zapper"))
 
-		monthKey := txTime.Format("2006-01")
-		month := monthly[monthKey]
-		if month != nil {
-			month.TransactionVolume.Add(month.TransactionVolume, amount)
+		if isPayment {
+			paymentsBySender[from] = append(paymentsBySender[from], analyticsPayment{From: from, Timestamp: tx.Timestamp})
+		}
+		if isReward {
+			rewards = append(rewards, analyticsReward{To: to, Amount: new(big.Int).Set(amount), Timestamp: tx.Timestamp})
 		}
 
-		addActiveAnalyticsUser(ownerByAddress, from, txTime, month, daily, monthlyActiveNow, monthlyActivePrevious, dailyActiveNow, monthStart, dayStart)
-		addActiveAnalyticsUser(ownerByAddress, to, txTime, month, daily, monthlyActiveNow, monthlyActivePrevious, dailyActiveNow, monthStart, dayStart)
-
-		if _, ok := paidAddressSet[from]; ok {
-			totalDistributed.Add(totalDistributed, amount)
-			if month != nil {
-				month.Distributed.Add(month.Distributed, amount)
-			}
-		}
-
-		merchantWallet := merchantByAddress[to]
-		if merchantWallet != nil {
-			fromMeta, fromKnown := ownerByAddress[from]
-			if fromKnown && fromMeta.UserID == merchantWallet.OwnerID {
+		for _, bucket := range periods {
+			if !bucket.contains(txTime) {
 				continue
 			}
-			if _, paid := paidAddressSet[from]; paid {
-				continue
+			bucket.Transactions++
+			bucket.TransactionVolume.Add(bucket.TransactionVolume, amount)
+			bucket.ActiveWallets[from] = struct{}{}
+			bucket.ActiveWallets[to] = struct{}{}
+			if isReward {
+				bucket.Rewards.Add(bucket.Rewards, amount)
+				bucket.RewardCount++
+				bucket.UniqueVolunteers[to] = struct{}{}
 			}
-			customerKey := from
-			if fromKnown && fromMeta.UserID != "" {
-				customerKey = fromMeta.UserID
+			if isPayment {
+				bucket.Payments.Add(bucket.Payments, amount)
+				if bucket.PaymentPairs[from] == nil {
+					bucket.PaymentPairs[from] = make(map[string]int)
+				}
+				bucket.PaymentPairs[from][to]++
 			}
-			merchantCustomers[customerKey]++
-			distributedSpentAtMerchants.Add(distributedSpentAtMerchants, amount)
-			if month != nil {
-				month.MerchantSpend.Add(month.MerchantSpend, amount)
-				month.MerchantCustomers[customerKey]++
+			if isRedemption {
+				bucket.Redemptions.Add(bucket.Redemptions, amount)
 			}
 		}
 	}
 
-	latencyTotal := int64(0)
-	latencyCount := int64(0)
-	for _, tx := range transfers {
-		if tx == nil {
-			continue
-		}
-		from := normalizeAnalyticsAddress(tx.From)
-		to := normalizeAnalyticsAddress(tx.To)
-		if _, ok := paidAddressSet[from]; !ok {
-			continue
-		}
-		for _, outgoing := range outgoingByAddress[to] {
-			if outgoing == nil || outgoing.Timestamp <= tx.Timestamp {
-				continue
-			}
-			outgoingTo := normalizeAnalyticsAddress(outgoing.To)
-			if outgoingTo == to {
-				continue
-			}
-			latencyTotal += int64(outgoing.Timestamp - tx.Timestamp)
-			latencyCount++
-			break
-		}
+	for _, list := range paymentsBySender {
+		sort.Slice(list, func(i, j int) bool { return list[i].Timestamp < list[j].Timestamp })
 	}
-
-	tokenUnused := minAnalyticsBigInt(registeredNonAdminBalance, totalDistributed)
-	tokenRedeemed := new(big.Int).Sub(new(big.Int).Set(totalDistributed), tokenUnused)
-	if tokenRedeemed.Sign() < 0 {
-		tokenRedeemed = big.NewInt(0)
-	}
-
-	totalProjectCost := big.NewInt(0)
-	projectCount := 0
-	for _, workflow := range workflowCosts {
-		if workflow == nil {
+	for _, reward := range rewards {
+		payment, ok := nextAnalyticsPayment(paymentsBySender[reward.To], reward.Timestamp)
+		if !ok {
 			continue
 		}
-		cost := parseAnalyticsBigInt(workflow.CostWei)
-		if cost.Sign() <= 0 {
+		seconds := int64(payment.Timestamp - reward.Timestamp)
+		if seconds <= 0 {
 			continue
 		}
-		totalProjectCost.Add(totalProjectCost, cost)
-		projectCount++
-		if workflow.CompletedAt > 0 {
-			completedAt := time.Unix(workflow.CompletedAt, 0).UTC()
-			if month := monthly[completedAt.Format("2006-01")]; month != nil {
-				month.ProjectCost.Add(month.ProjectCost, cost)
-				month.ProjectCount++
+		rewardTime := time.Unix(int64(reward.Timestamp), 0).UTC()
+		for _, bucket := range periods {
+			if bucket.contains(rewardTime) {
+				bucket.WeightedSpendSecs.Add(bucket.WeightedSpendSecs, new(big.Int).Mul(big.NewInt(seconds), reward.Amount))
+				bucket.WeightedSpendValue.Add(bucket.WeightedSpendValue, reward.Amount)
 			}
 		}
 	}
 
-	totalEventCodes := 0
-	totalRedeemedCodes := 0
-	eventPeriodStart := time.Time{}
-	eventPeriodEnd := time.Time{}
-	weeklyEarners := map[string]map[string]struct{}{}
-	monthlyEarners := map[string]map[string]struct{}{}
-	yearlyEarners := map[string]map[string]struct{}{}
-	for _, event := range volunteerEvents {
-		if event == nil {
-			continue
-		}
+	for _, event := range events {
 		eventTime := analyticsEventTime(event)
-		if !eventTime.IsZero() {
-			if eventPeriodStart.IsZero() || eventTime.Before(eventPeriodStart) {
-				eventPeriodStart = eventTime
-			}
-			if eventPeriodEnd.IsZero() || eventTime.After(eventPeriodEnd) {
-				eventPeriodEnd = eventTime
-			}
-			weekKey := analyticsWeekKey(eventTime)
-			monthKey := eventTime.Format("2006-01")
-			yearKey := eventTime.Format("2006")
-			if month := monthly[monthKey]; month != nil {
-				month.VolunteerEvents++
-			}
-			for _, earner := range event.EarnerAddresses {
-				address := normalizeAnalyticsAddress(earner)
-				if address == "" {
-					continue
-				}
-				analyticsAddNestedSet(weeklyEarners, weekKey, address)
-				analyticsAddNestedSet(monthlyEarners, monthKey, address)
-				analyticsAddNestedSet(yearlyEarners, yearKey, address)
-				if month := monthly[monthKey]; month != nil {
-					month.UniqueEarners[address] = struct{}{}
-				}
-			}
-		}
-		totalEventCodes += event.CodeCount
-		totalRedeemedCodes += event.RedeemedCount
-	}
-
-	repeatVolunteerEarners := 0
-	participationCount := 0
-	for _, count := range volunteerParticipation {
-		participationCount += count
-		if count > 1 {
-			repeatVolunteerEarners++
-		}
-	}
-
-	monthlyRows := make([]*structs.AdminAnalyticsMonthlyPoint, 0, len(monthlyOrder))
-	for _, key := range monthlyOrder {
-		bucket := monthly[key]
-		if bucket == nil {
+		if eventTime.IsZero() {
 			continue
 		}
-		monthlyRows = append(monthlyRows, &structs.AdminAnalyticsMonthlyPoint{
-			Key:                           bucket.Key,
-			Label:                         bucket.Label,
-			ActiveUsers:                   len(bucket.ActiveUsers),
-			TransactionVolumeWei:          analyticsBigIntString(bucket.TransactionVolume),
-			DistributedWei:                analyticsBigIntString(bucket.Distributed),
-			MerchantSpendWei:              analyticsBigIntString(bucket.MerchantSpend),
-			MerchantCustomerWallets:       len(bucket.MerchantCustomers),
-			MerchantRepeatCustomerWallets: analyticsRepeatCount(bucket.MerchantCustomers),
-			VolunteerEvents:               bucket.VolunteerEvents,
-			UniqueEarners:                 len(bucket.UniqueEarners),
-			AverageProjectCostWei:         analyticsAverage(bucket.ProjectCost, bucket.ProjectCount),
-		})
+		for _, bucket := range periods {
+			if bucket.contains(eventTime) {
+				bucket.Events++
+			}
+		}
 	}
 
-	dailyRows := make([]*structs.AdminAnalyticsDailyPoint, 0, len(dailyOrder))
-	for _, key := range dailyOrder {
-		bucket := daily[key]
-		if bucket == nil {
-			continue
-		}
-		dailyRows = append(dailyRows, &structs.AdminAnalyticsDailyPoint{
-			Key:         bucket.Key,
-			Label:       bucket.Label,
-			ActiveUsers: len(bucket.ActiveUsers),
-		})
+	periodRows := make([]*structs.AdminAnalyticsPeriod, 0, 7)
+	for _, bucket := range periods[:7] {
+		periodRows = append(periodRows, bucket.toPeriod())
+	}
+	trendRows := make([]*structs.AdminAnalyticsTrendPoint, 0, len(periods)-7)
+	for _, bucket := range periods[7:] {
+		trendRows = append(trendRows, bucket.toTrendPoint())
+	}
+
+	allTime := periods[6]
+	circulating := new(big.Int).Sub(new(big.Int).Set(allTime.Rewards), allTime.Redemptions)
+	if circulating.Sign() < 0 {
+		circulating = big.NewInt(0)
 	}
 
 	response := structs.AdminAnalyticsResponse{
-		GeneratedAt:             now.Unix(),
-		ConfiguredPaidAddresses: paidAddresses,
+		GeneratedAt: now.Unix(),
+		ChainID:     chainID,
 		Summary: structs.AdminAnalyticsSummary{
-			TotalActiveUsers:                 totalActiveUsers,
-			DailyActiveUsers:                 len(dailyActiveNow),
-			MonthlyActiveUsers:               len(monthlyActiveNow),
-			PreviousMonthlyActiveUsers:       len(monthlyActivePrevious),
-			MonthlyActiveUserChangePercent:   analyticsChangePercent(len(monthlyActiveNow), len(monthlyActivePrevious)),
-			MonthlyTransactionVolumeWei:      analyticsBigIntString(monthly[monthStart.Format("2006-01")].TransactionVolume),
-			TotalDistributedWei:              analyticsBigIntString(totalDistributed),
-			DistributedSpentAtMerchantsWei:   analyticsBigIntString(distributedSpentAtMerchants),
-			TokenRedeemedWei:                 analyticsBigIntString(tokenRedeemed),
-			TokenUnusedWei:                   analyticsBigIntString(tokenUnused),
-			TokenRedeemedPercent:             analyticsPercentage(tokenRedeemed, totalDistributed),
-			AverageCommunityProjectCostWei:   analyticsAverage(totalProjectCost, projectCount),
-			MerchantCustomerWallets:          len(merchantCustomers),
-			MerchantRepeatCustomerWallets:    analyticsRepeatCount(merchantCustomers),
-			MerchantRepeatCustomerPercent:    analyticsRatioPercent(analyticsRepeatCount(merchantCustomers), len(merchantCustomers)),
-			AverageSecondsToUseDistribution:  analyticsAverageInt64(latencyTotal, latencyCount),
-			AverageVolunteerEventsPerWeek:    analyticsAverageEvents(len(volunteerEvents), analyticsPeriodCount(eventPeriodStart, eventPeriodEnd, "week")),
-			AverageVolunteerEventsPerMonth:   analyticsAverageEvents(len(volunteerEvents), analyticsPeriodCount(eventPeriodStart, eventPeriodEnd, "month")),
-			AverageVolunteerEventsPerYear:    analyticsAverageEvents(len(volunteerEvents), analyticsPeriodCount(eventPeriodStart, eventPeriodEnd, "year")),
-			AverageUniqueEarnersPerWeek:      analyticsAverageNestedSet(weeklyEarners),
-			AverageUniqueEarnersPerMonth:     analyticsAverageNestedSet(monthlyEarners),
-			AverageUniqueEarnersPerYear:      analyticsAverageNestedSet(yearlyEarners),
-			VolunteerParticipationCount:      participationCount,
-			VolunteerUniqueEarners:           len(volunteerParticipation),
-			VolunteerRepeatEarners:           repeatVolunteerEarners,
-			VolunteerRepeatParticipationRate: analyticsRatioPercent(repeatVolunteerEarners, len(volunteerParticipation)),
-			VolunteerEvents:                  len(volunteerEvents),
-			EventCodeRedemptionPercent:       analyticsRatioPercent(totalRedeemedCodes, totalEventCodes),
+			CurrentCirculatingSFLUVWei: analyticsBigIntString(circulating),
 		},
-		Monthly:           monthlyRows,
-		Daily:             dailyRows,
-		MetricDefinitions: adminAnalyticsDefinitions(),
+		Periods:           periodRows,
+		MonthlyTrend:      trendRows,
+		MetricDefinitions: adminAnalyticsMetricDefinitions(),
+		Glossary:          adminAnalyticsGlossary(),
 	}
 
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(response)
 }
 
-func normalizeAnalyticsAddress(address string) string {
-	return strings.ToLower(strings.TrimSpace(address))
+func (p *PonderService) SyncAnalyticsWalletRoleHistory(ctx context.Context, chainID int64) error {
+	walletOwners, err := p.appDB.GetAnalyticsWalletOwners(ctx)
+	if err != nil {
+		return err
+	}
+	merchantWallets, err := p.appDB.GetAnalyticsMerchantWallets(ctx)
+	if err != nil {
+		return err
+	}
+	return p.appDB.SyncAnalyticsWalletRoleHistory(ctx, chainID, buildAnalyticsWalletRoleCandidates(chainID, walletOwners, merchantWallets))
 }
 
-func analyticsSetFromList(values []string) map[string]struct{} {
-	set := make(map[string]struct{}, len(values))
-	for _, value := range values {
-		normalized := normalizeAnalyticsAddress(value)
-		if normalized != "" {
-			set[normalized] = struct{}{}
+func (p *PonderService) SyncCurrentAnalyticsWalletRoleHistory(ctx context.Context) error {
+	return p.SyncAnalyticsWalletRoleHistory(ctx, analyticsChainID())
+}
+
+func buildAnalyticsWalletRoleCandidates(chainID int64, owners []*structs.AnalyticsWalletOwner, merchants []*structs.AnalyticsMerchantWallet) []appdb.AnalyticsWalletRoleCandidate {
+	candidates := make([]appdb.AnalyticsWalletRoleCandidate, 0)
+	appendCandidate := func(address string, role string, userID string, locationID int, source string) {
+		address = normalizeAnalyticsAddress(address)
+		if address == "" || address == analyticsZeroAddress {
+			return
+		}
+		candidates = append(candidates, appdb.AnalyticsWalletRoleCandidate{Address: address, Role: role, ChainID: chainID, UserID: userID, LocationID: locationID, Source: source})
+	}
+	for _, owner := range owners {
+		if owner == nil {
+			continue
+		}
+		if owner.IsAdmin {
+			appendCandidate(owner.Address, "admin", owner.UserID, 0, "users.is_admin")
+		}
+		if owner.IsMerchant {
+			appendCandidate(owner.Address, "merchant", owner.UserID, 0, "users.is_merchant")
 		}
 	}
-	return set
+	for _, merchant := range merchants {
+		if merchant == nil {
+			continue
+		}
+		appendCandidate(merchant.Address, "merchant", merchant.OwnerID, merchant.LocationID, "merchant_location")
+	}
+	for _, address := range utils.MergeAddressLists(utils.ParseAddressList(os.Getenv("PAID_ADMIN_ADDRESSES")), os.Getenv("ADMIN_ADDRESS")) {
+		appendCandidate(address, "admin", "", 0, "env.admin")
+	}
+	for _, address := range utils.MergeAddressLists(utils.ParseAddressList(os.Getenv("BOT_ADDRESS")), os.Getenv("FAUCET_ADDRESS"), os.Getenv("NEXT_PUBLIC_FAUCET_ADDRESS")) {
+		appendCandidate(address, "faucet", "", 0, "env.faucet")
+	}
+	for _, address := range utils.MergeAddressLists(utils.ParseAddressList(os.Getenv("ZAPPER_ADDRESS")), os.Getenv("NEXT_PUBLIC_ZAPPER_ADDRESS")) {
+		appendCandidate(address, "zapper", "", 0, "env.zapper")
+	}
+	return candidates
+}
+
+func analyticsChainID() int64 {
+	for _, key := range []string{"CHAIN_ID", "NEXT_PUBLIC_CHAIN_ID"} {
+		if value, err := strconv.ParseInt(strings.TrimSpace(os.Getenv(key)), 10, 64); err == nil && value > 0 {
+			return value
+		}
+	}
+	return 80094
+}
+
+func buildAnalyticsRoleIndex(records []*structs.AnalyticsWalletRoleRecord, chainID int64) analyticsRoleIndex {
+	index := make(analyticsRoleIndex)
+	for _, record := range records {
+		if record == nil || record.ChainID != chainID {
+			continue
+		}
+		address := normalizeAnalyticsAddress(record.Address)
+		if address == "" {
+			continue
+		}
+		index[address] = append(index[address], record)
+	}
+	return index
+}
+
+func (index analyticsRoleIndex) rolesAt(address string, at time.Time) analyticsRoleSet {
+	roles := make(analyticsRoleSet)
+	unix := at.Unix()
+	for _, record := range index[normalizeAnalyticsAddress(address)] {
+		if record == nil || record.StartedAt > unix {
+			continue
+		}
+		if record.EndedAt > 0 && record.EndedAt <= unix {
+			continue
+		}
+		roles[record.Role] = struct{}{}
+	}
+	return roles
+}
+
+func (roles analyticsRoleSet) has(role string) bool {
+	_, ok := roles[role]
+	return ok
+}
+
+func (roles analyticsRoleSet) isUserWallet() bool {
+	return !roles.has("admin") && !roles.has("merchant") && !roles.has("faucet") && !roles.has("zapper")
+}
+
+func newAnalyticsPeriod(key string, label string, unit string, start time.Time, end time.Time, allTime bool) *analyticsPeriodBucket {
+	return &analyticsPeriodBucket{
+		Key:                key,
+		Label:              label,
+		Unit:               unit,
+		Start:              start,
+		End:                end,
+		AllTime:            allTime,
+		ActiveUsers:        make(map[string]struct{}),
+		ActiveWallets:      make(map[string]struct{}),
+		TransactionVolume:  big.NewInt(0),
+		Rewards:            big.NewInt(0),
+		Payments:           big.NewInt(0),
+		PaymentPairs:       make(map[string]map[string]int),
+		Redemptions:        big.NewInt(0),
+		UniqueVolunteers:   make(map[string]struct{}),
+		WeightedSpendSecs:  big.NewInt(0),
+		WeightedSpendValue: big.NewInt(0),
+	}
+}
+
+func analyticsReportingPeriods(now time.Time) []*analyticsPeriodBucket {
+	now = now.UTC()
+	weekStart := startOfAnalyticsWeek(now)
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	yearStart := time.Date(now.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
+	periods := []*analyticsPeriodBucket{
+		newAnalyticsPeriod("current_week", "Current Week", "week", weekStart, weekStart.AddDate(0, 0, 7), false),
+		newAnalyticsPeriod("previous_week", "Previous Week", "week", weekStart.AddDate(0, 0, -7), weekStart, false),
+		newAnalyticsPeriod("current_month", "Current Month", "month", monthStart, monthStart.AddDate(0, 1, 0), false),
+		newAnalyticsPeriod("previous_month", "Previous Month", "month", monthStart.AddDate(0, -1, 0), monthStart, false),
+		newAnalyticsPeriod("current_year", "Current Year", "year", yearStart, yearStart.AddDate(1, 0, 0), false),
+		newAnalyticsPeriod("previous_year", "Previous Year", "year", yearStart.AddDate(-1, 0, 0), yearStart, false),
+		newAnalyticsPeriod("all_time", "All Time", "all_time", time.Unix(0, 0).UTC(), now.Add(time.Second), true),
+	}
+	for i := 11; i >= 0; i-- {
+		start := monthStart.AddDate(0, -i, 0)
+		periods = append(periods, newAnalyticsPeriod(start.Format("2006-01"), start.Format("Jan 2006"), "month", start, start.AddDate(0, 1, 0), false))
+	}
+	return periods
+}
+
+func startOfAnalyticsWeek(value time.Time) time.Time {
+	date := time.Date(value.Year(), value.Month(), value.Day(), 0, 0, 0, 0, time.UTC)
+	return date.AddDate(0, 0, -int(date.Weekday()))
+}
+
+func (bucket *analyticsPeriodBucket) contains(value time.Time) bool {
+	if bucket == nil {
+		return false
+	}
+	value = value.UTC()
+	return !value.Before(bucket.Start) && value.Before(bucket.End)
+}
+
+func (bucket *analyticsPeriodBucket) toPeriod() *structs.AdminAnalyticsPeriod {
+	return &structs.AdminAnalyticsPeriod{Key: bucket.Key, Label: bucket.Label, Unit: bucket.Unit, StartAt: bucket.Start.Unix(), EndAt: bucket.End.Unix() - 1, Metrics: bucket.metrics()}
+}
+
+func (bucket *analyticsPeriodBucket) toTrendPoint() *structs.AdminAnalyticsTrendPoint {
+	return &structs.AdminAnalyticsTrendPoint{Key: bucket.Key, Label: bucket.Label, StartAt: bucket.Start.Unix(), EndAt: bucket.End.Unix() - 1, Metrics: bucket.metrics()}
+}
+
+func (bucket *analyticsPeriodBucket) metrics() []*structs.AdminAnalyticsMetricValue {
+	return []*structs.AdminAnalyticsMetricValue{
+		{MetricKey: "active_users", Label: "Active Users", Kind: "count", Count: len(bucket.ActiveUsers)},
+		{MetricKey: "active_wallets", Label: "Active Wallets", Kind: "count", Count: len(bucket.ActiveWallets)},
+		{MetricKey: "transactions", Label: "Transactions", Kind: "count", Count: bucket.Transactions},
+		{MetricKey: "transaction_volume", Label: "Transaction Volume", Kind: "wei", Wei: analyticsBigIntString(bucket.TransactionVolume)},
+		{MetricKey: "rewards", Label: "Rewards", Kind: "wei", Wei: analyticsBigIntString(bucket.Rewards)},
+		{MetricKey: "total_payments", Label: "Total Payments", Kind: "wei", Wei: analyticsBigIntString(bucket.Payments)},
+		{MetricKey: "total_sfluv_distributed", Label: "Total SFLUV Distributed", Kind: "wei", Wei: analyticsBigIntString(bucket.Rewards)},
+		{MetricKey: "usage_percentage", Label: "Usage Percentage", Kind: "percent", Percent: analyticsRatioPercentBig(bucket.Payments, bucket.Rewards)},
+		{MetricKey: "unique_volunteers", Label: "Unique Volunteers", Kind: "count", Count: len(bucket.UniqueVolunteers)},
+		{MetricKey: "volunteer_frequency", Label: "Volunteer Frequency", Kind: "decimal", Decimal: analyticsAverageFloat(bucket.RewardCount, len(bucket.UniqueVolunteers))},
+		{MetricKey: "repeat_business", Label: "Repeat Business", Kind: "count", Count: analyticsRepeatBusiness(bucket.PaymentPairs)},
+		{MetricKey: "value_weighted_average_time_to_spend", Label: "Value-Weighted Average Time to Spend", Kind: "seconds", Seconds: analyticsWeightedAverageSeconds(bucket.WeightedSpendSecs, bucket.WeightedSpendValue)},
+		{MetricKey: "event_frequency", Label: "Event Frequency", Kind: "decimal", Decimal: float64(bucket.Events)},
+	}
+}
+
+func analyticsRepeatBusiness(pairs map[string]map[string]int) int {
+	repeat := make(map[string]struct{})
+	for userWallet, merchantCounts := range pairs {
+		for _, count := range merchantCounts {
+			if count >= 2 {
+				repeat[userWallet] = struct{}{}
+			}
+		}
+	}
+	return len(repeat)
+}
+
+func analyticsWeightedAverageSeconds(total *big.Int, value *big.Int) int64 {
+	if total == nil || value == nil || value.Sign() <= 0 {
+		return 0
+	}
+	return new(big.Int).Div(new(big.Int).Set(total), value).Int64()
+}
+
+func analyticsAverageFloat(total int, count int) float64 {
+	if total <= 0 || count <= 0 {
+		return 0
+	}
+	return math.Round((float64(total)/float64(count))*10) / 10
+}
+
+func nextAnalyticsPayment(payments []analyticsPayment, after uint64) (analyticsPayment, bool) {
+	for _, payment := range payments {
+		if payment.Timestamp > after {
+			return payment, true
+		}
+	}
+	return analyticsPayment{}, false
+}
+
+func normalizeAnalyticsAddress(address string) string {
+	return strings.ToLower(strings.TrimSpace(address))
 }
 
 func parseAnalyticsBigInt(value string) *big.Int {
@@ -455,22 +459,8 @@ func analyticsBigIntString(value *big.Int) string {
 	return value.String()
 }
 
-func analyticsAverage(total *big.Int, count int) string {
-	if total == nil || total.Sign() <= 0 || count <= 0 {
-		return "0"
-	}
-	return new(big.Int).Div(new(big.Int).Set(total), big.NewInt(int64(count))).String()
-}
-
-func analyticsPercentage(part *big.Int, total *big.Int) float64 {
-	if part == nil || total == nil || total.Sign() <= 0 {
-		return 0
-	}
-	return analyticsRatioPercentBig(part, total)
-}
-
 func analyticsRatioPercentBig(part *big.Int, total *big.Int) float64 {
-	if total == nil || total.Sign() <= 0 {
+	if part == nil || total == nil || total.Sign() <= 0 {
 		return 0
 	}
 	partFloat, _ := new(big.Float).SetInt(part).Float64()
@@ -479,86 +469,6 @@ func analyticsRatioPercentBig(part *big.Int, total *big.Int) float64 {
 		return 0
 	}
 	return math.Round((partFloat/totalFloat)*1000) / 10
-}
-
-func analyticsRatioPercent(part int, total int) float64 {
-	if part <= 0 || total <= 0 {
-		return 0
-	}
-	return math.Round((float64(part)/float64(total))*1000) / 10
-}
-
-func analyticsChangePercent(current int, previous int) float64 {
-	if previous <= 0 {
-		if current > 0 {
-			return 100
-		}
-		return 0
-	}
-	return math.Round(((float64(current-previous)/float64(previous))*100)*10) / 10
-}
-
-func analyticsAverageInt64(total int64, count int64) int64 {
-	if total <= 0 || count <= 0 {
-		return 0
-	}
-	return total / count
-}
-
-func minAnalyticsBigInt(a *big.Int, b *big.Int) *big.Int {
-	if a == nil {
-		return big.NewInt(0)
-	}
-	if b == nil {
-		return new(big.Int).Set(a)
-	}
-	if a.Cmp(b) <= 0 {
-		return new(big.Int).Set(a)
-	}
-	return new(big.Int).Set(b)
-}
-
-func addActiveAnalyticsUser(
-	ownerByAddress map[string]adminAnalyticsOwnerMeta,
-	address string,
-	txTime time.Time,
-	month *adminAnalyticsMonthBucket,
-	daily map[string]*adminAnalyticsDayBucket,
-	monthlyActiveNow map[string]struct{},
-	monthlyActivePrevious map[string]struct{},
-	dailyActiveNow map[string]struct{},
-	monthStart time.Time,
-	dayStart time.Time,
-) {
-	meta, ok := ownerByAddress[address]
-	if !ok || meta.IsAdmin || meta.UserID == "" {
-		return
-	}
-	if month != nil {
-		month.ActiveUsers[meta.UserID] = struct{}{}
-	}
-	if day := daily[txTime.Format("2006-01-02")]; day != nil {
-		day.ActiveUsers[meta.UserID] = struct{}{}
-	}
-	if !txTime.Before(monthStart) {
-		monthlyActiveNow[meta.UserID] = struct{}{}
-	}
-	if !txTime.Before(monthStart.AddDate(0, -1, 0)) && txTime.Before(monthStart) {
-		monthlyActivePrevious[meta.UserID] = struct{}{}
-	}
-	if !txTime.Before(dayStart) {
-		dailyActiveNow[meta.UserID] = struct{}{}
-	}
-}
-
-func analyticsRepeatCount(counts map[string]int) int {
-	repeat := 0
-	for _, count := range counts {
-		if count > 1 {
-			repeat++
-		}
-	}
-	return repeat
 }
 
 func analyticsEventTime(event *structs.AnalyticsVolunteerEvent) time.Time {
@@ -574,74 +484,36 @@ func analyticsEventTime(event *structs.AnalyticsVolunteerEvent) time.Time {
 	return time.Time{}
 }
 
-func analyticsWeekKey(value time.Time) string {
-	year, week := value.ISOWeek()
-	return strconv.Itoa(year) + "-W" + fmtAnalyticsTwoDigit(week)
-}
-
-func fmtAnalyticsTwoDigit(value int) string {
-	if value < 10 {
-		return "0" + strconv.Itoa(value)
-	}
-	return strconv.Itoa(value)
-}
-
-func analyticsAddNestedSet(target map[string]map[string]struct{}, key string, value string) {
-	if key == "" || value == "" {
-		return
-	}
-	set := target[key]
-	if set == nil {
-		set = make(map[string]struct{})
-		target[key] = set
-	}
-	set[value] = struct{}{}
-}
-
-func analyticsAverageNestedSet(target map[string]map[string]struct{}) float64 {
-	if len(target) == 0 {
-		return 0
-	}
-	total := 0
-	for _, set := range target {
-		total += len(set)
-	}
-	return math.Round((float64(total)/float64(len(target)))*10) / 10
-}
-
-func analyticsAverageEvents(count int, periods int) float64 {
-	if count <= 0 || periods <= 0 {
-		return 0
-	}
-	return math.Round((float64(count)/float64(periods))*10) / 10
-}
-
-func analyticsPeriodCount(start time.Time, end time.Time, unit string) int {
-	if start.IsZero() || end.IsZero() || end.Before(start) {
-		return 0
-	}
-	switch unit {
-	case "week":
-		days := end.Sub(start).Hours() / 24
-		return int(math.Floor(days/7)) + 1
-	case "month":
-		return (end.Year()-start.Year())*12 + int(end.Month()-start.Month()) + 1
-	case "year":
-		return end.Year() - start.Year() + 1
-	default:
-		return 0
-	}
-}
-
-func adminAnalyticsDefinitions() []structs.AdminAnalyticsDefinition {
+func adminAnalyticsMetricDefinitions() []structs.AdminAnalyticsDefinition {
 	return []structs.AdminAnalyticsDefinition{
-		{Key: "active_users", Label: "Active users", Definition: "Registered non-admin users with at least one indexed SFLuv transfer in the daily or monthly window."},
-		{Key: "transaction_volume", Label: "Monthly transaction volume", Definition: "Gross SFLuv transfer volume from the indexed ERC20 transfer table for the month."},
-		{Key: "redeemed_vs_unused", Label: "Redeemed vs unused", Definition: "Total distributed SFLuv from configured paid admin/faucet addresses, minus current positive registered non-admin wallet balances, capped at distributed amount."},
-		{Key: "project_cost", Label: "Community project cost", Definition: "Average bounty cost of completed or paid-out workflows using workflow total bounty, falling back to summed step bounties plus manager bounty."},
-		{Key: "merchant_traffic", Label: "Merchant traffic and repeat business", Definition: "Wallet-based proxy: unique non-admin customer wallets sending SFLuv to approved merchant wallets, plus wallets with more than one merchant payment."},
-		{Key: "distributed_spent", Label: "Distributed spent at merchants", Definition: "SFLuv sent to approved merchant wallets by non-admin wallets, excluding self-payments and direct paid-admin distributions."},
-		{Key: "time_to_use", Label: "Time to use after distribution", Definition: "Average time between a paid-admin/faucet distribution and the recipient wallet's next outgoing SFLuv transfer."},
-		{Key: "volunteer_events", Label: "Volunteer events and earners", Definition: "Bot event and redemption-code data, grouped by event start time when present, otherwise expiration time."},
+		{Key: "current_circulating_sfluv", Label: "Current Circulating SFLUV", Definition: "All-time total SFLUV distributed through rewards minus all-time redemptions."},
+		{Key: "active_users", Label: "Active Users", Definition: "Users with an observed authenticated web or mobile session in the period."},
+		{Key: "active_wallets", Label: "Active Wallets", Definition: "Wallet addresses with at least one confirmed SFLUV transfer in the period."},
+		{Key: "transactions", Label: "Transactions", Definition: "Confirmed SFLUV blockchain transfers in the period."},
+		{Key: "transaction_volume", Label: "Transaction Volume", Definition: "Aggregate SFLUV value transferred in confirmed SFLUV transfers in the period."},
+		{Key: "rewards", Label: "Rewards", Definition: "Aggregate SFLUV value sent from admin or faucet wallets to user wallets in the period."},
+		{Key: "total_payments", Label: "Total Payments", Definition: "Aggregate SFLUV value sent from user wallets to merchant wallets in the period."},
+		{Key: "total_sfluv_distributed", Label: "Total SFLUV Distributed", Definition: "Same calculation as rewards: aggregate admin/faucet to user-wallet transfers in the period."},
+		{Key: "usage_percentage", Label: "Usage Percentage", Definition: "Payments divided by rewards for the period."},
+		{Key: "unique_volunteers", Label: "Unique Volunteers", Definition: "Unique user wallets that received at least one reward in the period."},
+		{Key: "volunteer_frequency", Label: "Volunteer Frequency", Definition: "Reward count divided by unique volunteer wallets in the period."},
+		{Key: "repeat_business", Label: "Repeat Business", Definition: "User wallets that made at least two payments to the same merchant wallet in the period."},
+		{Key: "value_weighted_average_time_to_spend", Label: "Value-Weighted Average Time to Spend", Definition: "Sum of reward time to next payment multiplied by reward value, divided by aggregate reward value."},
+		{Key: "event_frequency", Label: "Event Frequency", Definition: "Bot DB events occurring in the period."},
+	}
+}
+
+func adminAnalyticsGlossary() []structs.AdminAnalyticsDefinition {
+	return []structs.AdminAnalyticsDefinition{
+		{Key: "users", Label: "Users", Definition: "An entry in the users table with one or more attached wallets. Users are platform specific."},
+		{Key: "wallets", Label: "Wallets", Definition: "Any address that has engaged with SFLUV by sending or receiving a transfer."},
+		{Key: "admin_wallet", Label: "Admin Wallet", Definition: "A wallet associated with an admin user, with historical wallet role records respected by timestamp and chain."},
+		{Key: "merchant_wallet", Label: "Merchant Wallet", Definition: "A wallet associated with a merchant user or merchant location, with historical wallet role records respected by timestamp and chain."},
+		{Key: "faucet_wallet", Label: "Faucet Wallet", Definition: "A backend-controlled payout wallet, with historical wallet role records respected by timestamp and chain."},
+		{Key: "zapper_wallet", Label: "Zapper Wallet", Definition: "The configured zapper wallet, with historical wallet role records respected by timestamp and chain."},
+		{Key: "user_wallet", Label: "User Wallet", Definition: "Any wallet not classified as admin, merchant, faucet, or zapper at the transfer timestamp."},
+		{Key: "payment", Label: "Payment", Definition: "A transfer from a user wallet to a merchant wallet."},
+		{Key: "reward", Label: "Reward", Definition: "A transfer from an admin or faucet wallet to a user wallet."},
+		{Key: "redemption", Label: "Redemption", Definition: "A transfer from a merchant wallet to an admin or zapper wallet."},
 	}
 }

--- a/backend/handlers/app.go
+++ b/backend/handlers/app.go
@@ -1,6 +1,11 @@
 package handlers
 
 import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/SFLuv/app/backend/db"
 	"github.com/SFLuv/app/backend/logger"
 )
@@ -28,4 +33,21 @@ func (a *AppService) SetBotService(bot *BotService) {
 
 func (a *AppService) SetMinterService(minter *MinterService) {
 	a.minter = minter
+}
+
+func (a *AppService) RecordAnalyticsUserActivity(ctx context.Context, userID string, r *http.Request) {
+	if a == nil || a.db == nil {
+		return
+	}
+	platform := "web"
+	if r != nil {
+		if header := strings.TrimSpace(r.Header.Get("X-SFLUV-Client-Platform")); header != "" {
+			platform = header
+		} else if strings.Contains(strings.ToLower(r.UserAgent()), "mobile") {
+			platform = "mobile"
+		}
+	}
+	if err := a.db.RecordAnalyticsUserActivity(ctx, userID, platform, time.Now().UTC()); err != nil && a.logger != nil {
+		a.logger.Logf("error recording analytics user activity for %s: %s", userID, err)
+	}
 }

--- a/backend/router/router.go
+++ b/backend/router/router.go
@@ -366,9 +366,11 @@ func requireAcceptedAuthedUser(w http.ResponseWriter, r *http.Request, s *handle
 
 func withActiveAuth(handlerFunc http.HandlerFunc, s *handlers.AppService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if _, ok := requireAcceptedAuthedUser(w, r, s); !ok {
+		id, ok := requireAcceptedAuthedUser(w, r, s)
+		if !ok {
 			return
 		}
+		s.RecordAnalyticsUserActivity(r.Context(), id, r)
 
 		handlerFunc(w, r)
 	}
@@ -399,6 +401,7 @@ func withAdmin(handlerFunc http.HandlerFunc, s *handlers.AppService) http.Handle
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
+		s.RecordAnalyticsUserActivity(r.Context(), id, r)
 
 		handlerFunc(w, r)
 	}

--- a/backend/structs/admin_analytics.go
+++ b/backend/structs/admin_analytics.go
@@ -7,6 +7,16 @@ type AnalyticsWalletOwner struct {
 	IsMerchant bool   `json:"is_merchant"`
 }
 
+type AnalyticsWalletRoleRecord struct {
+	Address    string `json:"address"`
+	Role       string `json:"role"`
+	ChainID    int64  `json:"chain_id"`
+	UserID     string `json:"user_id"`
+	LocationID int    `json:"location_id"`
+	StartedAt  int64  `json:"started_at"`
+	EndedAt    int64  `json:"ended_at"`
+}
+
 type AnalyticsMerchantWallet struct {
 	OwnerID      string `json:"owner_id"`
 	LocationID   int    `json:"location_id"`
@@ -46,54 +56,35 @@ type AnalyticsWorkflowCost struct {
 }
 
 type AdminAnalyticsSummary struct {
-	TotalActiveUsers                 int     `json:"total_active_users"`
-	DailyActiveUsers                 int     `json:"daily_active_users"`
-	MonthlyActiveUsers               int     `json:"monthly_active_users"`
-	PreviousMonthlyActiveUsers       int     `json:"previous_monthly_active_users"`
-	MonthlyActiveUserChangePercent   float64 `json:"monthly_active_user_change_percent"`
-	MonthlyTransactionVolumeWei      string  `json:"monthly_transaction_volume_wei"`
-	TotalDistributedWei              string  `json:"total_distributed_wei"`
-	DistributedSpentAtMerchantsWei   string  `json:"distributed_spent_at_merchants_wei"`
-	TokenRedeemedWei                 string  `json:"token_redeemed_wei"`
-	TokenUnusedWei                   string  `json:"token_unused_wei"`
-	TokenRedeemedPercent             float64 `json:"token_redeemed_percent"`
-	AverageCommunityProjectCostWei   string  `json:"average_community_project_cost_wei"`
-	MerchantCustomerWallets          int     `json:"merchant_customer_wallets"`
-	MerchantRepeatCustomerWallets    int     `json:"merchant_repeat_customer_wallets"`
-	MerchantRepeatCustomerPercent    float64 `json:"merchant_repeat_customer_percent"`
-	AverageSecondsToUseDistribution  int64   `json:"average_seconds_to_use_distribution"`
-	AverageVolunteerEventsPerWeek    float64 `json:"average_volunteer_events_per_week"`
-	AverageVolunteerEventsPerMonth   float64 `json:"average_volunteer_events_per_month"`
-	AverageVolunteerEventsPerYear    float64 `json:"average_volunteer_events_per_year"`
-	AverageUniqueEarnersPerWeek      float64 `json:"average_unique_earners_per_week"`
-	AverageUniqueEarnersPerMonth     float64 `json:"average_unique_earners_per_month"`
-	AverageUniqueEarnersPerYear      float64 `json:"average_unique_earners_per_year"`
-	VolunteerParticipationCount      int     `json:"volunteer_participation_count"`
-	VolunteerUniqueEarners           int     `json:"volunteer_unique_earners"`
-	VolunteerRepeatEarners           int     `json:"volunteer_repeat_earners"`
-	VolunteerRepeatParticipationRate float64 `json:"volunteer_repeat_participation_rate"`
-	VolunteerEvents                  int     `json:"volunteer_events"`
-	EventCodeRedemptionPercent       float64 `json:"event_code_redemption_percent"`
+	CurrentCirculatingSFLUVWei string `json:"current_circulating_sfluv_wei"`
 }
 
-type AdminAnalyticsMonthlyPoint struct {
-	Key                           string `json:"key"`
-	Label                         string `json:"label"`
-	ActiveUsers                   int    `json:"active_users"`
-	TransactionVolumeWei          string `json:"transaction_volume_wei"`
-	DistributedWei                string `json:"distributed_wei"`
-	MerchantSpendWei              string `json:"merchant_spend_wei"`
-	MerchantCustomerWallets       int    `json:"merchant_customer_wallets"`
-	MerchantRepeatCustomerWallets int    `json:"merchant_repeat_customer_wallets"`
-	VolunteerEvents               int    `json:"volunteer_events"`
-	UniqueEarners                 int    `json:"unique_earners"`
-	AverageProjectCostWei         string `json:"average_project_cost_wei"`
+type AdminAnalyticsMetricValue struct {
+	MetricKey string  `json:"metric_key"`
+	Label     string  `json:"label"`
+	Kind      string  `json:"kind"`
+	Wei       string  `json:"wei,omitempty"`
+	Count     int     `json:"count,omitempty"`
+	Seconds   int64   `json:"seconds,omitempty"`
+	Percent   float64 `json:"percent,omitempty"`
+	Decimal   float64 `json:"decimal,omitempty"`
 }
 
-type AdminAnalyticsDailyPoint struct {
-	Key         string `json:"key"`
-	Label       string `json:"label"`
-	ActiveUsers int    `json:"active_users"`
+type AdminAnalyticsPeriod struct {
+	Key     string                       `json:"key"`
+	Label   string                       `json:"label"`
+	Unit    string                       `json:"unit"`
+	StartAt int64                        `json:"start_at"`
+	EndAt   int64                        `json:"end_at"`
+	Metrics []*AdminAnalyticsMetricValue `json:"metrics"`
+}
+
+type AdminAnalyticsTrendPoint struct {
+	Key     string                       `json:"key"`
+	Label   string                       `json:"label"`
+	StartAt int64                        `json:"start_at"`
+	EndAt   int64                        `json:"end_at"`
+	Metrics []*AdminAnalyticsMetricValue `json:"metrics"`
 }
 
 type AdminAnalyticsDefinition struct {
@@ -103,10 +94,11 @@ type AdminAnalyticsDefinition struct {
 }
 
 type AdminAnalyticsResponse struct {
-	GeneratedAt             int64                         `json:"generated_at"`
-	ConfiguredPaidAddresses []string                      `json:"configured_paid_addresses"`
-	Summary                 AdminAnalyticsSummary         `json:"summary"`
-	Monthly                 []*AdminAnalyticsMonthlyPoint `json:"monthly"`
-	Daily                   []*AdminAnalyticsDailyPoint   `json:"daily"`
-	MetricDefinitions       []AdminAnalyticsDefinition    `json:"metric_definitions"`
+	GeneratedAt       int64                       `json:"generated_at"`
+	ChainID           int64                       `json:"chain_id"`
+	Summary           AdminAnalyticsSummary       `json:"summary"`
+	Periods           []*AdminAnalyticsPeriod     `json:"periods"`
+	MonthlyTrend      []*AdminAnalyticsTrendPoint `json:"monthly_trend"`
+	MetricDefinitions []AdminAnalyticsDefinition  `json:"metric_definitions"`
+	Glossary          []AdminAnalyticsDefinition  `json:"glossary"`
 }

--- a/frontend/components/admin/admin-analytics-panel.tsx
+++ b/frontend/components/admin/admin-analytics-panel.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useMemo, useState } from "react"
 import {
   Activity,
-  ArrowDownToLine,
+  BarChart3,
+  Clipboard,
   Clock3,
   Coins,
   Download,
@@ -11,19 +12,58 @@ import {
   Repeat2,
   Store,
   Users,
+  Wallet,
   type LucideIcon,
 } from "lucide-react"
 
-import { useApp } from "@/context/AppProvider"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
+import { useApp } from "@/context/AppProvider"
 import { SFLUV_DECIMALS } from "@/lib/constants"
-import type { AdminAnalyticsResponse } from "@/types/admin-analytics"
+import type {
+  AdminAnalyticsDefinition,
+  AdminAnalyticsMetricValue,
+  AdminAnalyticsPeriod,
+  AdminAnalyticsResponse,
+  AdminAnalyticsTrendPoint,
+} from "@/types/admin-analytics"
 
 const tokenFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 })
 const decimalFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 })
 const countFormatter = new Intl.NumberFormat("en-US")
+
+const metricIcons: Record<string, LucideIcon> = {
+  active_users: Users,
+  active_wallets: Wallet,
+  transactions: Activity,
+  transaction_volume: BarChart3,
+  rewards: Coins,
+  total_payments: Store,
+  total_sfluv_distributed: Coins,
+  usage_percentage: BarChart3,
+  unique_volunteers: Users,
+  volunteer_frequency: Repeat2,
+  repeat_business: Store,
+  value_weighted_average_time_to_spend: Clock3,
+  event_frequency: Activity,
+}
+
+const orderedMetricKeys = [
+  "active_users",
+  "active_wallets",
+  "transactions",
+  "transaction_volume",
+  "rewards",
+  "total_payments",
+  "total_sfluv_distributed",
+  "usage_percentage",
+  "unique_volunteers",
+  "volunteer_frequency",
+  "repeat_business",
+  "value_weighted_average_time_to_spend",
+  "event_frequency",
+]
 
 const weiToNumber = (value?: string): number => {
   try {
@@ -40,15 +80,32 @@ const weiToNumber = (value?: string): number => {
 const formatToken = (value?: string): string => `${tokenFormatter.format(weiToNumber(value))} SFLuv`
 const formatCount = (value?: number): string => countFormatter.format(value || 0)
 const formatPercent = (value?: number): string => `${decimalFormatter.format(value || 0)}%`
+const formatDecimal = (value?: number): string => decimalFormatter.format(value || 0)
 
 const formatDuration = (seconds?: number): string => {
   const value = seconds || 0
-  if (value <= 0) return "No usage yet"
+  if (value <= 0) return "No spend yet"
   const days = value / 86400
   if (days >= 1) return `${decimalFormatter.format(days)} days`
   const hours = value / 3600
   if (hours >= 1) return `${decimalFormatter.format(hours)} hours`
   return `${Math.max(1, Math.round(value / 60))} min`
+}
+
+const formatMetricValue = (metric?: AdminAnalyticsMetricValue): string => {
+  if (!metric) return "0"
+  if (metric.kind === "wei") return formatToken(metric.wei)
+  if (metric.kind === "count") return formatCount(metric.count)
+  if (metric.kind === "percent") return formatPercent(metric.percent)
+  if (metric.kind === "seconds") return formatDuration(metric.seconds)
+  return formatDecimal(metric.decimal)
+}
+
+const periodRange = (period: AdminAnalyticsPeriod | AdminAnalyticsTrendPoint): string => {
+  if (period.key === "all_time") return "All indexed time"
+  const start = new Date(period.start_at * 1000)
+  const end = new Date(period.end_at * 1000)
+  return `${start.toLocaleDateString()} - ${end.toLocaleDateString()}`
 }
 
 const csvEscape = (value: unknown): string => {
@@ -69,71 +126,138 @@ const downloadTextFile = (filename: string, content: string) => {
   URL.revokeObjectURL(url)
 }
 
+const metricCsvValue = (metric: AdminAnalyticsMetricValue): string | number => {
+  if (metric.kind === "wei") return weiToNumber(metric.wei)
+  if (metric.kind === "count") return metric.count || 0
+  if (metric.kind === "percent") return metric.percent || 0
+  if (metric.kind === "seconds") return metric.seconds || 0
+  return metric.decimal || 0
+}
+
 const buildAnalyticsCsv = (analytics: AdminAnalyticsResponse): string => {
   const rows: unknown[][] = [
-    ["section", "key", "label", "value", "notes"],
-    ["summary", "generated_at", "Generated At", new Date(analytics.generated_at * 1000).toISOString(), ""],
-    ["summary", "configured_paid_addresses", "Configured Paid Addresses", analytics.configured_paid_addresses.join(" "), ""],
-    ["summary", "total_active_users", "Total Active Users", analytics.summary.total_active_users, ""],
-    ["summary", "daily_active_users", "Daily Active Users", analytics.summary.daily_active_users, ""],
-    ["summary", "monthly_active_users", "Monthly Active Users", analytics.summary.monthly_active_users, ""],
-    ["summary", "monthly_transaction_volume_sfluv", "Monthly Transaction Volume", weiToNumber(analytics.summary.monthly_transaction_volume_wei), "SFLuv"],
-    ["summary", "total_distributed_sfluv", "Total Distributed", weiToNumber(analytics.summary.total_distributed_wei), "SFLuv"],
-    ["summary", "distributed_spent_at_merchants_sfluv", "Distributed Spent At Merchants", weiToNumber(analytics.summary.distributed_spent_at_merchants_wei), "SFLuv"],
-    ["summary", "token_redeemed_percent", "Redeemed Token Percent", analytics.summary.token_redeemed_percent, "%"],
-    ["summary", "average_project_cost_sfluv", "Average Community Project Cost", weiToNumber(analytics.summary.average_community_project_cost_wei), "SFLuv"],
-    ["summary", "merchant_repeat_customer_percent", "Merchant Repeat Customer Percent", analytics.summary.merchant_repeat_customer_percent, "%"],
-    ["summary", "average_seconds_to_use_distribution", "Average Seconds To Use Distribution", analytics.summary.average_seconds_to_use_distribution, ""],
-    ["summary", "volunteer_events", "Volunteer Events", analytics.summary.volunteer_events, ""],
-    ["summary", "volunteer_unique_earners", "Volunteer Unique Earners", analytics.summary.volunteer_unique_earners, ""],
-    ["summary", "volunteer_repeat_participation_rate", "Volunteer Repeat Participation Rate", analytics.summary.volunteer_repeat_participation_rate, "%"],
+    ["section", "period_key", "period_label", "metric_key", "metric_label", "value", "unit", "notes"],
+    ["summary", "", "Current", "current_circulating_sfluv", "Current Circulating SFLUV", weiToNumber(analytics.summary.current_circulating_sfluv_wei), "SFLuv", "All-time rewards minus redemptions"],
+    ["summary", "", "Generated", "generated_at", "Generated At", new Date(analytics.generated_at * 1000).toISOString(), "", ""],
+    ["summary", "", "Chain", "chain_id", "Chain ID", analytics.chain_id, "", ""],
+    ...analytics.periods.flatMap((period) =>
+      period.metrics.map((metric) => [
+        "period",
+        period.key,
+        period.label,
+        metric.metric_key,
+        metric.label,
+        metricCsvValue(metric),
+        metric.kind === "wei" ? "SFLuv" : metric.kind,
+        periodRange(period),
+      ]),
+    ),
+    ...analytics.monthly_trend.flatMap((period) =>
+      period.metrics.map((metric) => [
+        "monthly_trend",
+        period.key,
+        period.label,
+        metric.metric_key,
+        metric.label,
+        metricCsvValue(metric),
+        metric.kind === "wei" ? "SFLuv" : metric.kind,
+        periodRange(period),
+      ]),
+    ),
     [],
-    ["monthly", "key", "label", "active_users", "transaction_volume_sfluv", "distributed_sfluv", "merchant_spend_sfluv", "merchant_customer_wallets", "merchant_repeat_customer_wallets", "volunteer_events", "unique_earners", "average_project_cost_sfluv"],
-    ...analytics.monthly.map((point) => [
-      "monthly",
-      point.key,
-      point.label,
-      point.active_users,
-      weiToNumber(point.transaction_volume_wei),
-      weiToNumber(point.distributed_wei),
-      weiToNumber(point.merchant_spend_wei),
-      point.merchant_customer_wallets,
-      point.merchant_repeat_customer_wallets,
-      point.volunteer_events,
-      point.unique_earners,
-      weiToNumber(point.average_project_cost_wei),
-    ]),
+    ["definition", "", "", "key", "label", "definition", "", ""],
+    ...analytics.metric_definitions.map((definition) => ["definition", "", "", definition.key, definition.label, definition.definition, "", ""]),
     [],
-    ["daily", "key", "label", "active_users"],
-    ...analytics.daily.map((point) => ["daily", point.key, point.label, point.active_users]),
-    [],
-    ["definition", "key", "label", "definition"],
-    ...analytics.metric_definitions.map((definition) => ["definition", definition.key, definition.label, definition.definition]),
+    ["glossary", "", "", "key", "label", "definition", "", ""],
+    ...analytics.glossary.map((definition) => ["glossary", "", "", definition.key, definition.label, definition.definition, "", ""]),
   ]
 
   return rows.map((row) => row.map(csvEscape).join(",")).join("\n")
 }
 
-function MetricCard({
-  title,
-  value,
-  detail,
-  icon: Icon,
+const escapeSvg = (value: string): string =>
+  value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;")
+
+const copyMetricImage = async (title: string, value: string, detail: string) => {
+  const width = 880
+  const height = 420
+  const svg = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+      <rect width="100%" height="100%" rx="24" fill="#fffafa"/>
+      <rect x="24" y="24" width="${width - 48}" height="${height - 48}" rx="20" fill="#ffffff" stroke="#f1d9d6" stroke-width="3"/>
+      <text x="72" y="112" font-family="Inter, Arial, sans-serif" font-size="38" font-weight="700" fill="#252936">${escapeSvg(title)}</text>
+      <text x="72" y="230" font-family="Inter, Arial, sans-serif" font-size="72" font-weight="800" fill="#252936">${escapeSvg(value)}</text>
+      <text x="72" y="304" font-family="Inter, Arial, sans-serif" font-size="30" fill="#667085">${escapeSvg(detail)}</text>
+      <text x="72" y="358" font-family="Inter, Arial, sans-serif" font-size="22" fill="#eb6c6c">SFLuv analytics</text>
+    </svg>`
+  const image = new Image()
+  const blob = new Blob([svg], { type: "image/svg+xml;charset=utf-8" })
+  const url = URL.createObjectURL(blob)
+  image.src = url
+  await new Promise<void>((resolve, reject) => {
+    image.onload = () => resolve()
+    image.onerror = () => reject(new Error("Unable to render metric image."))
+  })
+  const canvas = document.createElement("canvas")
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext("2d")
+  if (!ctx) throw new Error("Unable to render metric image.")
+  ctx.drawImage(image, 0, 0)
+  URL.revokeObjectURL(url)
+  const png = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/png"))
+  if (!navigator.clipboard) {
+    return
+  }
+  if (!png || !("ClipboardItem" in window)) {
+    await navigator.clipboard.writeText(`${title}: ${value} (${detail})`)
+    return
+  }
+  await navigator.clipboard.write([new ClipboardItem({ "image/png": png })])
+}
+
+const definitionFor = (definitions: AdminAnalyticsDefinition[], key: string): string =>
+  definitions.find((definition) => definition.key === key)?.definition || ""
+
+function MetricTile({
+  metric,
+  definition,
+  periodLabel,
 }: {
-  title: string
-  value: string
-  detail: string
-  icon: LucideIcon
+  metric: AdminAnalyticsMetricValue
+  definition: string
+  periodLabel: string
 }) {
+  const Icon = metricIcons[metric.metric_key] || Activity
+  const [copied, setCopied] = useState(false)
+  const value = formatMetricValue(metric)
+  const copy = async () => {
+    try {
+      await copyMetricImage(metric.label, value, periodLabel)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      setCopied(false)
+    }
+  }
+
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">{title}</CardTitle>
-        <Icon className="h-4 w-4 text-[#eb6c6c]" />
+      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0 pb-3">
+        <div className="min-w-0">
+          <CardTitle className="text-sm font-medium">{metric.label}</CardTitle>
+          <CardDescription className="mt-1 line-clamp-2 text-xs">{definition}</CardDescription>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <Icon className="h-4 w-4 text-[#eb6c6c]" />
+          <Button type="button" size="icon" variant="ghost" className="h-8 w-8" onClick={copy} title="Copy metric image">
+            <Clipboard className="h-4 w-4" />
+          </Button>
+        </div>
       </CardHeader>
       <CardContent>
-        <div className="text-2xl font-semibold">{value}</div>
-        <p className="mt-1 text-xs text-muted-foreground">{detail}</p>
+        <div className="text-2xl font-semibold leading-tight">{value}</div>
+        <p className="mt-2 min-h-5 text-xs text-muted-foreground">{copied ? "Copied image to clipboard" : periodLabel}</p>
       </CardContent>
     </Card>
   )
@@ -142,6 +266,7 @@ function MetricCard({
 export function AdminAnalyticsPanel() {
   const { authFetch, status, user } = useApp()
   const [analytics, setAnalytics] = useState<AdminAnalyticsResponse | null>(null)
+  const [selectedPeriodKey, setSelectedPeriodKey] = useState("current_month")
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState("")
 
@@ -170,12 +295,13 @@ export function AdminAnalyticsPanel() {
     }
   }, [authFetch, status, user?.isAdmin])
 
-  const maxMonthlyVolume = useMemo(() => {
-    return Math.max(...(analytics?.monthly || []).map((point) => weiToNumber(point.transaction_volume_wei)), 1)
-  }, [analytics])
+  const selectedPeriod = useMemo(() => {
+    if (!analytics) return null
+    return analytics.periods.find((period) => period.key === selectedPeriodKey) || analytics.periods[0] || null
+  }, [analytics, selectedPeriodKey])
 
-  const maxDailyActive = useMemo(() => {
-    return Math.max(...(analytics?.daily || []).map((point) => point.active_users), 1)
+  const maxMonthlyVolume = useMemo(() => {
+    return Math.max(...(analytics?.monthly_trend || []).map((point) => weiToNumber(point.metrics.find((metric) => metric.metric_key === "transaction_volume")?.wei)), 1)
   }, [analytics])
 
   const exportCsv = () => {
@@ -204,12 +330,11 @@ export function AdminAnalyticsPanel() {
     )
   }
 
-  if (!analytics) return null
+  if (!analytics || !selectedPeriod) return null
 
-  const summary = analytics.summary
-  const paidAddressStatus = analytics.configured_paid_addresses.length > 0
-    ? `${analytics.configured_paid_addresses.length} paid source address${analytics.configured_paid_addresses.length === 1 ? "" : "es"} configured`
-    : "No paid source addresses configured"
+  const sortedMetrics = orderedMetricKeys
+    .map((key) => selectedPeriod.metrics.find((metric) => metric.metric_key === key))
+    .filter((metric): metric is AdminAnalyticsMetricValue => Boolean(metric))
 
   return (
     <div className="space-y-6">
@@ -220,163 +345,123 @@ export function AdminAnalyticsPanel() {
               <Activity className="h-5 w-5 text-[#eb6c6c]" />
               Analytics
             </CardTitle>
-            <CardDescription>
-              Internal reporting for financials, grant narratives, merchant activity, and volunteer participation.
-            </CardDescription>
+            <CardDescription>Glossary-based internal reporting for SFLuv circulation, rewards, payments, redemptions, and volunteering.</CardDescription>
           </div>
           <div className="flex flex-col gap-2 sm:items-end">
             <Button onClick={exportCsv}>
               <Download className="mr-2 h-4 w-4" />
               Export CSV
             </Button>
-            <Badge variant={analytics.configured_paid_addresses.length > 0 ? "secondary" : "destructive"}>
-              {paidAddressStatus}
-            </Badge>
+            <Badge variant="secondary">Chain {analytics.chain_id}</Badge>
           </div>
         </CardHeader>
       </Card>
 
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <MetricCard
-          title="Active Users"
-          value={formatCount(summary.monthly_active_users)}
-          detail={`${formatCount(summary.daily_active_users)} today, ${formatPercent(summary.monthly_active_user_change_percent)} vs prior month`}
-          icon={Users}
-        />
-        <MetricCard
-          title="Monthly Volume"
-          value={formatToken(summary.monthly_transaction_volume_wei)}
-          detail="Gross indexed SFLuv transfer volume this month"
-          icon={Coins}
-        />
-        <MetricCard
-          title="Redeemed Tokens"
-          value={formatPercent(summary.token_redeemed_percent)}
-          detail={`${formatToken(summary.token_redeemed_wei)} used, ${formatToken(summary.token_unused_wei)} still held`}
-          icon={ArrowDownToLine}
-        />
-        <MetricCard
-          title="Avg Project Cost"
-          value={formatToken(summary.average_community_project_cost_wei)}
-          detail="Completed and paid-out workflow bounty average"
-          icon={Activity}
-        />
-        <MetricCard
-          title="Merchant Customers"
-          value={formatCount(summary.merchant_customer_wallets)}
-          detail={`${formatCount(summary.merchant_repeat_customer_wallets)} repeat wallets (${formatPercent(summary.merchant_repeat_customer_percent)})`}
-          icon={Store}
-        />
-        <MetricCard
-          title="Total Distributed"
-          value={formatToken(summary.total_distributed_wei)}
-          detail={`${formatToken(summary.distributed_spent_at_merchants_wei)} spent at merchants`}
-          icon={Coins}
-        />
-        <MetricCard
-          title="Time To Use"
-          value={formatDuration(summary.average_seconds_to_use_distribution)}
-          detail="Average first outgoing transfer after distribution"
-          icon={Clock3}
-        />
-        <MetricCard
-          title="Volunteer Frequency"
-          value={formatCount(summary.volunteer_participation_count)}
-          detail={`${formatCount(summary.volunteer_repeat_earners)} repeat earners (${formatPercent(summary.volunteer_repeat_participation_rate)})`}
-          icon={Repeat2}
-        />
-      </div>
+      <Card>
+        <CardHeader className="gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle>Current Circulating SFLUV</CardTitle>
+            <CardDescription>All-time total SFLUV distributed through rewards minus all-time redemptions.</CardDescription>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => copyMetricImage("Current Circulating SFLUV", formatToken(analytics.summary.current_circulating_sfluv_wei), "All-time rewards minus redemptions")}
+          >
+            <Clipboard className="mr-2 h-4 w-4" />
+            Copy Image
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <div className="text-4xl font-semibold tracking-normal">{formatToken(analytics.summary.current_circulating_sfluv_wei)}</div>
+        </CardContent>
+      </Card>
 
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.65fr)]">
-        <Card>
-          <CardHeader>
-            <CardTitle>Monthly Reporting Trend</CardTitle>
-            <CardDescription>Volume, merchant spend, active users, volunteer events, and unique earners.</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {analytics.monthly.map((point) => {
-              const volume = weiToNumber(point.transaction_volume_wei)
-              const width = Math.max(3, Math.round((volume / maxMonthlyVolume) * 100))
-              return (
-                <div key={point.key} className="grid gap-2 md:grid-cols-[92px_minmax(0,1fr)_220px] md:items-center">
-                  <div className="text-sm font-medium">{point.label}</div>
-                  <div className="h-3 overflow-hidden rounded-full bg-secondary">
-                    <div className="h-full rounded-full bg-[#eb6c6c]" style={{ width: `${width}%` }} />
-                  </div>
-                  <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                    <span>{formatToken(point.transaction_volume_wei)}</span>
-                    <span>{formatCount(point.active_users)} active</span>
-                    <span>{formatToken(point.merchant_spend_wei)} merchants</span>
-                    <span>{formatCount(point.unique_earners)} earners</span>
-                  </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Period Metrics</CardTitle>
+          <CardDescription>Weeks run Sunday through Saturday; months and years use calendar boundaries.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          <div className="flex flex-wrap gap-2">
+            {analytics.periods.map((period) => (
+              <Button
+                key={period.key}
+                type="button"
+                size="sm"
+                variant={period.key === selectedPeriod.key ? "default" : "outline"}
+                onClick={() => setSelectedPeriodKey(period.key)}
+              >
+                {period.label}
+              </Button>
+            ))}
+          </div>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {sortedMetrics.map((metric) => (
+              <MetricTile
+                key={metric.metric_key}
+                metric={metric}
+                definition={definitionFor(analytics.metric_definitions, metric.metric_key)}
+                periodLabel={periodRange(selectedPeriod)}
+              />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Monthly Trend</CardTitle>
+          <CardDescription>Last 12 calendar months using the same glossary calculations.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {analytics.monthly_trend.map((point) => {
+            const transactionVolumeMetric = point.metrics.find((metric) => metric.metric_key === "transaction_volume")
+            const volume = weiToNumber(transactionVolumeMetric?.wei)
+            const rewards = formatMetricValue(point.metrics.find((metric) => metric.metric_key === "rewards"))
+            const payments = formatMetricValue(point.metrics.find((metric) => metric.metric_key === "total_payments"))
+            const volunteers = formatMetricValue(point.metrics.find((metric) => metric.metric_key === "unique_volunteers"))
+            const width = Math.max(3, Math.round((volume / maxMonthlyVolume) * 100))
+            return (
+              <div key={point.key} className="grid gap-2 md:grid-cols-[92px_minmax(0,1fr)_280px] md:items-center">
+                <div className="text-sm font-medium">{point.label}</div>
+                <div className="h-3 overflow-hidden rounded-full bg-secondary">
+                  <div className="h-full rounded-full bg-[#eb6c6c]" style={{ width: `${width}%` }} />
                 </div>
-              )
-            })}
-          </CardContent>
-        </Card>
+                <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                  <span>{formatMetricValue(transactionVolumeMetric)}</span>
+                  <span>{volunteers} volunteers</span>
+                  <span>{rewards} rewards</span>
+                  <span>{payments} payments</span>
+                </div>
+              </div>
+            )
+          })}
+        </CardContent>
+      </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Daily Active Users</CardTitle>
-            <CardDescription>Last 30 days from indexed transfer activity.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="flex h-56 items-end gap-1">
-              {analytics.daily.map((point) => {
-                const height = Math.max(4, Math.round((point.active_users / maxDailyActive) * 100))
-                return (
-                  <div key={point.key} className="flex min-w-0 flex-1 flex-col items-center gap-2">
-                    <div className="w-full rounded-t bg-[#eb6c6c]" style={{ height: `${height}%` }} title={`${point.label}: ${point.active_users}`} />
-                    <span className="hidden text-[10px] text-muted-foreground sm:block">{point.label.split(" ")[1]}</span>
-                  </div>
-                )
-              })}
-            </div>
-          </CardContent>
-        </Card>
+      <div className="grid gap-6 xl:grid-cols-2">
+        <DefinitionList title="Metric Definitions" items={analytics.metric_definitions} />
+        <DefinitionList title="Glossary" items={analytics.glossary} />
       </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Volunteer And Earner Averages</CardTitle>
-          <CardDescription>Event averages use bot event timing; unique earners use redemption addresses.</CardDescription>
-        </CardHeader>
-        <CardContent className="grid gap-4 md:grid-cols-3">
-          <div className="rounded-md border p-4">
-            <div className="text-sm text-muted-foreground">Events</div>
-            <div className="mt-2 text-xl font-semibold">{decimalFormatter.format(summary.average_volunteer_events_per_week)} / week</div>
-            <div className="text-sm text-muted-foreground">{decimalFormatter.format(summary.average_volunteer_events_per_month)} / month</div>
-            <div className="text-sm text-muted-foreground">{decimalFormatter.format(summary.average_volunteer_events_per_year)} / year</div>
-          </div>
-          <div className="rounded-md border p-4">
-            <div className="text-sm text-muted-foreground">Unique Earners</div>
-            <div className="mt-2 text-xl font-semibold">{decimalFormatter.format(summary.average_unique_earners_per_week)} / week</div>
-            <div className="text-sm text-muted-foreground">{decimalFormatter.format(summary.average_unique_earners_per_month)} / month</div>
-            <div className="text-sm text-muted-foreground">{decimalFormatter.format(summary.average_unique_earners_per_year)} / year</div>
-          </div>
-          <div className="rounded-md border p-4">
-            <div className="text-sm text-muted-foreground">Code Redemption</div>
-            <div className="mt-2 text-xl font-semibold">{formatPercent(summary.event_code_redemption_percent)}</div>
-            <div className="text-sm text-muted-foreground">{formatCount(summary.volunteer_events)} total events</div>
-            <div className="text-sm text-muted-foreground">{formatCount(summary.volunteer_unique_earners)} total unique earners</div>
-          </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Metric Definitions</CardTitle>
-          <CardDescription>Export includes these definitions so finance and grant work keeps the same assumptions.</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          {analytics.metric_definitions.map((definition) => (
-            <div key={definition.key} className="rounded-md border p-3">
-              <div className="font-medium">{definition.label}</div>
-              <p className="mt-1 text-sm text-muted-foreground">{definition.definition}</p>
-            </div>
-          ))}
-        </CardContent>
-      </Card>
     </div>
+  )
+}
+
+function DefinitionList({ title, items }: { title: string; items: AdminAnalyticsDefinition[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {items.map((definition) => (
+          <div key={definition.key} className="rounded-md border p-3">
+            <div className="font-medium">{definition.label}</div>
+            <p className="mt-1 text-sm text-muted-foreground">{definition.definition}</p>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
   )
 }

--- a/frontend/types/admin-analytics.ts
+++ b/frontend/types/admin-analytics.ts
@@ -1,52 +1,33 @@
 export interface AdminAnalyticsSummary {
-  total_active_users: number
-  daily_active_users: number
-  monthly_active_users: number
-  previous_monthly_active_users: number
-  monthly_active_user_change_percent: number
-  monthly_transaction_volume_wei: string
-  total_distributed_wei: string
-  distributed_spent_at_merchants_wei: string
-  token_redeemed_wei: string
-  token_unused_wei: string
-  token_redeemed_percent: number
-  average_community_project_cost_wei: string
-  merchant_customer_wallets: number
-  merchant_repeat_customer_wallets: number
-  merchant_repeat_customer_percent: number
-  average_seconds_to_use_distribution: number
-  average_volunteer_events_per_week: number
-  average_volunteer_events_per_month: number
-  average_volunteer_events_per_year: number
-  average_unique_earners_per_week: number
-  average_unique_earners_per_month: number
-  average_unique_earners_per_year: number
-  volunteer_participation_count: number
-  volunteer_unique_earners: number
-  volunteer_repeat_earners: number
-  volunteer_repeat_participation_rate: number
-  volunteer_events: number
-  event_code_redemption_percent: number
+  current_circulating_sfluv_wei: string
 }
 
-export interface AdminAnalyticsMonthlyPoint {
-  key: string
+export interface AdminAnalyticsMetricValue {
+  metric_key: string
   label: string
-  active_users: number
-  transaction_volume_wei: string
-  distributed_wei: string
-  merchant_spend_wei: string
-  merchant_customer_wallets: number
-  merchant_repeat_customer_wallets: number
-  volunteer_events: number
-  unique_earners: number
-  average_project_cost_wei: string
+  kind: "wei" | "count" | "seconds" | "percent" | "decimal"
+  wei?: string
+  count?: number
+  seconds?: number
+  percent?: number
+  decimal?: number
 }
 
-export interface AdminAnalyticsDailyPoint {
+export interface AdminAnalyticsPeriod {
   key: string
   label: string
-  active_users: number
+  unit: string
+  start_at: number
+  end_at: number
+  metrics: AdminAnalyticsMetricValue[]
+}
+
+export interface AdminAnalyticsTrendPoint {
+  key: string
+  label: string
+  start_at: number
+  end_at: number
+  metrics: AdminAnalyticsMetricValue[]
 }
 
 export interface AdminAnalyticsDefinition {
@@ -57,9 +38,10 @@ export interface AdminAnalyticsDefinition {
 
 export interface AdminAnalyticsResponse {
   generated_at: number
-  configured_paid_addresses: string[]
+  chain_id: number
   summary: AdminAnalyticsSummary
-  monthly: AdminAnalyticsMonthlyPoint[]
-  daily: AdminAnalyticsDailyPoint[]
+  periods: AdminAnalyticsPeriod[]
+  monthly_trend: AdminAnalyticsTrendPoint[]
   metric_definitions: AdminAnalyticsDefinition[]
+  glossary: AdminAnalyticsDefinition[]
 }


### PR DESCRIPTION
## Summary

- Reworks the admin analytics dashboard around the glossary-defined metrics and period model.
- Adds historical wallet role tracking for admin, merchant, faucet, and zapper addresses, including chain ID and active time windows.
- Tracks authenticated user activity locally for the new active-user metric.
- Updates the admin analytics UI to show only the approved metrics, export CSVs, and copy individual metric cards as images.

## Validation

- `cd backend && go test -vet=off ./db ./handlers ./router ./structs`
- `cd frontend && npx tsc --noEmit --pretty false 2>&1 | rg "admin-analytics|admin/page|types/admin-analytics" || true`
- Local smoke test against restored prod `app`, `bot`, and `ponder` dumps with backend on `localhost:8080` and frontend on `localhost:3000`.

## Notes

- `analytics_user_activity` only accumulates active-user history after deploy.
- Existing wallet role records are initially backfilled from epoch for current known roles so older transfer history can be classified until more precise historical role data exists.
