### PR TITLE
[codex] Track client versions for migration readiness

### DIFF
--- a/backend/bootstrap/schema_migrations.go
+++ b/backend/bootstrap/schema_migrations.go
@@ -629,7 +629,7 @@ var schemaMigrations = []SchemaMigration{
 			if _, err := pools.App.Exec(ctx, `
 				CREATE TABLE IF NOT EXISTS user_client_versions(
 					id BIGSERIAL PRIMARY KEY,
-					user_id TEXT REFERENCES users(id) ON DELETE CASCADE,
+					user_id TEXT,
 					client_key TEXT NOT NULL,
 					platform TEXT NOT NULL DEFAULT '',
 					version TEXT NOT NULL DEFAULT '',

--- a/backend/bootstrap/schema_migrations.go
+++ b/backend/bootstrap/schema_migrations.go
@@ -594,6 +594,68 @@ var schemaMigrations = []SchemaMigration{
 			return nil
 		},
 	},
+	{
+		Version:     "1.14",
+		Description: "seed historical analytics faucet wallet for fiscal-year backfill",
+		Apply: func(ctx context.Context, pools *DBPools, appLogger *logger.LogCloser) error {
+			if _, err := pools.App.Exec(ctx, `
+					INSERT INTO analytics_wallet_role_history(address, role, chain_id, source, started_at, ended_at)
+					SELECT
+						'0x6c28631f17f2b6b6e9349ec8e7eba3827318bce3',
+						'faucet',
+						80094,
+						'historical.manual.old_faucet_2025_08',
+						TIMESTAMPTZ '2025-07-01 00:00:00+00',
+						TIMESTAMPTZ '2026-02-01 00:00:00+00'
+					WHERE NOT EXISTS (
+						SELECT 1
+						FROM analytics_wallet_role_history
+						WHERE LOWER(address) = '0x6c28631f17f2b6b6e9349ec8e7eba3827318bce3'
+						AND role = 'faucet'
+						AND chain_id = 80094
+						AND source = 'historical.manual.old_faucet_2025_08'
+					);
+				`); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	},
+	{
+		Version:     "1.15",
+		Description: "track mobile client versions for migration readiness",
+		Apply: func(ctx context.Context, pools *DBPools, appLogger *logger.LogCloser) error {
+			if _, err := pools.App.Exec(ctx, `
+				CREATE TABLE IF NOT EXISTS user_client_versions(
+					id BIGSERIAL PRIMARY KEY,
+					user_id TEXT REFERENCES users(id) ON DELETE CASCADE,
+					client_key TEXT NOT NULL,
+					platform TEXT NOT NULL DEFAULT '',
+					version TEXT NOT NULL DEFAULT '',
+					build TEXT NOT NULL DEFAULT '',
+					build_number INTEGER NOT NULL DEFAULT 0,
+					user_agent TEXT NOT NULL DEFAULT '',
+					source TEXT NOT NULL DEFAULT '',
+					legacy_inferred BOOLEAN NOT NULL DEFAULT FALSE,
+					first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+					last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+				);
+
+				CREATE UNIQUE INDEX IF NOT EXISTS user_client_versions_client_key_idx
+					ON user_client_versions(client_key);
+				CREATE INDEX IF NOT EXISTS user_client_versions_user_last_seen_idx
+					ON user_client_versions(user_id, last_seen_at DESC)
+					WHERE user_id IS NOT NULL;
+				CREATE INDEX IF NOT EXISTS user_client_versions_version_build_idx
+					ON user_client_versions(LOWER(version), LOWER(build));
+			`); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	},
 }
 
 type versionTarget struct {

--- a/backend/db/app.go
+++ b/backend/db/app.go
@@ -2735,7 +2735,7 @@ func (s *AppDB) CreateTables() error {
 	_, err = s.db.Exec(context.Background(), `
 		CREATE TABLE IF NOT EXISTS user_client_versions(
 			id BIGSERIAL PRIMARY KEY,
-			user_id TEXT REFERENCES users(id) ON DELETE CASCADE,
+			user_id TEXT,
 			client_key TEXT NOT NULL,
 			platform TEXT NOT NULL DEFAULT '',
 			version TEXT NOT NULL DEFAULT '',

--- a/backend/db/app.go
+++ b/backend/db/app.go
@@ -2732,5 +2732,33 @@ func (s *AppDB) CreateTables() error {
 		return fmt.Errorf("error creating w9 submissions table: %s", err)
 	}
 
+	_, err = s.db.Exec(context.Background(), `
+		CREATE TABLE IF NOT EXISTS user_client_versions(
+			id BIGSERIAL PRIMARY KEY,
+			user_id TEXT REFERENCES users(id) ON DELETE CASCADE,
+			client_key TEXT NOT NULL,
+			platform TEXT NOT NULL DEFAULT '',
+			version TEXT NOT NULL DEFAULT '',
+			build TEXT NOT NULL DEFAULT '',
+			build_number INTEGER NOT NULL DEFAULT 0,
+			user_agent TEXT NOT NULL DEFAULT '',
+			source TEXT NOT NULL DEFAULT '',
+			legacy_inferred BOOLEAN NOT NULL DEFAULT FALSE,
+			first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+
+		CREATE UNIQUE INDEX IF NOT EXISTS user_client_versions_client_key_idx
+			ON user_client_versions(client_key);
+		CREATE INDEX IF NOT EXISTS user_client_versions_user_last_seen_idx
+			ON user_client_versions(user_id, last_seen_at DESC)
+			WHERE user_id IS NOT NULL;
+		CREATE INDEX IF NOT EXISTS user_client_versions_version_build_idx
+			ON user_client_versions(LOWER(version), LOWER(build));
+	`)
+	if err != nil {
+		return fmt.Errorf("error creating user client versions table: %s", err)
+	}
+
 	return nil
 }

--- a/backend/db/app_client_version.go
+++ b/backend/db/app_client_version.go
@@ -1,0 +1,303 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/SFLuv/app/backend/structs"
+)
+
+func normalizeClientVersionLabel(version string, build string) string {
+	version = strings.TrimSpace(version)
+	build = strings.TrimSpace(build)
+	if version == "" {
+		version = "unknown"
+	}
+	if build == "" {
+		return version
+	}
+	return fmt.Sprintf("%s (%s)", version, build)
+}
+
+func (a *AppDB) RecordClientVersionObservation(ctx context.Context, observation structs.ClientVersionObservation) error {
+	if strings.TrimSpace(observation.ClientKey) == "" {
+		return nil
+	}
+
+	seenAt := observation.SeenAt
+	if seenAt.IsZero() {
+		seenAt = time.Now().UTC()
+	}
+
+	var userID any
+	if strings.TrimSpace(observation.UserId) != "" {
+		userID = strings.TrimSpace(observation.UserId)
+	}
+
+	_, err := a.db.Exec(ctx, `
+		INSERT INTO user_client_versions(
+			user_id,
+			client_key,
+			platform,
+			version,
+			build,
+			build_number,
+			user_agent,
+			source,
+			legacy_inferred,
+			first_seen_at,
+			last_seen_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10)
+		ON CONFLICT (client_key)
+		DO UPDATE SET
+			user_id = COALESCE(EXCLUDED.user_id, user_client_versions.user_id),
+			platform = CASE
+				WHEN EXCLUDED.platform <> '' THEN EXCLUDED.platform
+				ELSE user_client_versions.platform
+			END,
+			version = CASE
+				WHEN EXCLUDED.version <> '' THEN EXCLUDED.version
+				ELSE user_client_versions.version
+			END,
+			build = CASE
+				WHEN EXCLUDED.build <> '' THEN EXCLUDED.build
+				ELSE user_client_versions.build
+			END,
+			build_number = CASE
+				WHEN EXCLUDED.build_number > 0 THEN EXCLUDED.build_number
+				ELSE user_client_versions.build_number
+			END,
+			user_agent = CASE
+				WHEN EXCLUDED.user_agent <> '' THEN EXCLUDED.user_agent
+				ELSE user_client_versions.user_agent
+			END,
+			source = CASE
+				WHEN EXCLUDED.source <> '' THEN EXCLUDED.source
+				ELSE user_client_versions.source
+			END,
+			legacy_inferred = EXCLUDED.legacy_inferred,
+			first_seen_at = LEAST(user_client_versions.first_seen_at, EXCLUDED.first_seen_at),
+			last_seen_at = GREATEST(user_client_versions.last_seen_at, EXCLUDED.last_seen_at);
+	`,
+		userID,
+		strings.TrimSpace(observation.ClientKey),
+		strings.TrimSpace(observation.Platform),
+		strings.TrimSpace(observation.Version),
+		strings.TrimSpace(observation.Build),
+		observation.BuildNumber,
+		strings.TrimSpace(observation.UserAgent),
+		strings.TrimSpace(observation.Source),
+		observation.LegacyInferred,
+		seenAt,
+	)
+	if err != nil {
+		return fmt.Errorf("error recording client version observation: %s", err)
+	}
+
+	return nil
+}
+
+func (a *AppDB) AttachClientVersionDevices(ctx context.Context, users []*structs.User) error {
+	if len(users) == 0 {
+		return nil
+	}
+
+	userIDs := make([]string, 0, len(users))
+	userByID := make(map[string]*structs.User, len(users))
+	for _, user := range users {
+		if user == nil || user.Id == "" {
+			continue
+		}
+		userIDs = append(userIDs, user.Id)
+		user.ClientDevices = []*structs.ClientVersionDevice{}
+		userByID[user.Id] = user
+	}
+	if len(userIDs) == 0 {
+		return nil
+	}
+
+	rows, err := a.db.Query(ctx, `
+		SELECT
+			id,
+			COALESCE(user_id, ''),
+			platform,
+			version,
+			build,
+			source,
+			legacy_inferred,
+			first_seen_at,
+			last_seen_at
+		FROM
+			user_client_versions
+		WHERE
+			user_id = ANY($1)
+		ORDER BY
+			user_id ASC,
+			last_seen_at DESC,
+			id DESC;
+	`, userIDs)
+	if err != nil {
+		return fmt.Errorf("error getting client version devices: %s", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		device := &structs.ClientVersionDevice{}
+		if err := rows.Scan(
+			&device.Id,
+			&device.UserId,
+			&device.Platform,
+			&device.Version,
+			&device.Build,
+			&device.Source,
+			&device.LegacyInferred,
+			&device.FirstSeenAt,
+			&device.LastSeenAt,
+		); err != nil {
+			return fmt.Errorf("error scanning client version device: %s", err)
+		}
+		device.VersionLabel = normalizeClientVersionLabel(device.Version, device.Build)
+		if user := userByID[device.UserId]; user != nil {
+			user.ClientDevices = append(user.ClientDevices, device)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("error reading client version devices: %s", err)
+	}
+
+	return nil
+}
+
+func (a *AppDB) GetClientVersionFilterOptions(ctx context.Context) ([]string, error) {
+	rows, err := a.db.Query(ctx, `
+		SELECT
+			CASE
+				WHEN TRIM(version) = '' THEN 'unknown'
+				WHEN TRIM(build) <> '' THEN TRIM(version) || ' (' || TRIM(build) || ')'
+				ELSE TRIM(version)
+			END AS version_label
+		FROM
+			user_client_versions
+		WHERE
+			user_id IS NOT NULL
+		GROUP BY
+			1
+		ORDER BY
+			MAX(last_seen_at) DESC
+		LIMIT 100;
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("error getting client version filter options: %s", err)
+	}
+	defer rows.Close()
+
+	options := []string{}
+	for rows.Next() {
+		var option string
+		if err := rows.Scan(&option); err != nil {
+			return nil, fmt.Errorf("error scanning client version filter option: %s", err)
+		}
+		options = append(options, option)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error reading client version filter options: %s", err)
+	}
+
+	return options, nil
+}
+
+func (a *AppDB) GetClientVersionUserCounts(ctx context.Context) ([]*structs.ClientVersionUserCount, error) {
+	rows, err := a.db.Query(ctx, `
+		WITH active_users AS (
+			SELECT
+				id
+			FROM
+				users
+			WHERE
+				active = TRUE
+		),
+		latest_versions AS (
+			SELECT DISTINCT ON (ucv.user_id)
+				ucv.user_id,
+				TRIM(ucv.version) AS version,
+				TRIM(ucv.build) AS build,
+				ucv.legacy_inferred,
+				ucv.last_seen_at
+			FROM
+				user_client_versions ucv
+			INNER JOIN
+				active_users au
+			ON
+				au.id = ucv.user_id
+			ORDER BY
+				ucv.user_id,
+				ucv.last_seen_at DESC,
+				ucv.id DESC
+		),
+		version_counts AS (
+			SELECT
+				CASE
+					WHEN COALESCE(lv.version, '') = '' THEN 'Unknown / no version'
+					WHEN COALESCE(lv.build, '') <> '' THEN lv.version || ' (' || lv.build || ')'
+					ELSE lv.version
+				END AS version_label,
+				COALESCE(lv.version, '') AS version,
+				COALESCE(lv.build, '') AS build,
+				COALESCE(lv.legacy_inferred, FALSE) AS legacy_inferred,
+				lv.user_id IS NULL AS unknown,
+				COUNT(*)::INTEGER AS user_count,
+				MAX(lv.last_seen_at) AS latest_seen
+			FROM
+				active_users au
+			LEFT JOIN
+				latest_versions lv
+			ON
+				lv.user_id = au.id
+			GROUP BY
+				1, 2, 3, 4, 5
+		)
+		SELECT
+			version_label,
+			version,
+			build,
+			user_count,
+			legacy_inferred,
+			unknown
+		FROM
+			version_counts
+		ORDER BY
+			unknown ASC,
+			legacy_inferred DESC,
+			latest_seen DESC NULLS LAST,
+			user_count DESC,
+			version_label ASC;
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("error getting client version user counts: %s", err)
+	}
+	defer rows.Close()
+
+	counts := []*structs.ClientVersionUserCount{}
+	for rows.Next() {
+		count := &structs.ClientVersionUserCount{}
+		if err := rows.Scan(
+			&count.VersionLabel,
+			&count.Version,
+			&count.Build,
+			&count.UserCount,
+			&count.LegacyInferred,
+			&count.Unknown,
+		); err != nil {
+			return nil, fmt.Errorf("error scanning client version user count: %s", err)
+		}
+		counts = append(counts, count)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error reading client version user counts: %s", err)
+	}
+
+	return counts, nil
+}

--- a/backend/db/app_client_version.go
+++ b/backend/db/app_client_version.go
@@ -173,6 +173,25 @@ func (a *AppDB) AttachClientVersionDevices(ctx context.Context, users []*structs
 
 func (a *AppDB) GetClientVersionFilterOptions(ctx context.Context) ([]string, error) {
 	rows, err := a.db.Query(ctx, `
+		WITH latest_versions AS (
+			SELECT DISTINCT ON (ucv.user_id)
+				ucv.user_id,
+				TRIM(ucv.version) AS version,
+				TRIM(ucv.build) AS build,
+				ucv.last_seen_at
+			FROM
+				user_client_versions ucv
+			INNER JOIN
+				users u
+			ON
+				u.id = ucv.user_id
+			WHERE
+				u.active = TRUE
+			ORDER BY
+				ucv.user_id,
+				ucv.last_seen_at DESC,
+				ucv.id DESC
+		)
 		SELECT
 			CASE
 				WHEN TRIM(version) = '' THEN 'unknown'
@@ -180,9 +199,7 @@ func (a *AppDB) GetClientVersionFilterOptions(ctx context.Context) ([]string, er
 				ELSE TRIM(version)
 			END AS version_label
 		FROM
-			user_client_versions
-		WHERE
-			user_id IS NOT NULL
+			latest_versions
 		GROUP BY
 			1
 		ORDER BY

--- a/backend/db/app_user.go
+++ b/backend/db/app_user.go
@@ -190,6 +190,19 @@ func appendUserListFilters(where []string, args []any, search string, versionFil
 				user_client_versions ucv
 			WHERE
 				ucv.user_id = users.id
+			AND
+				ucv.id = (
+					SELECT
+						latest_ucv.id
+					FROM
+						user_client_versions latest_ucv
+					WHERE
+						latest_ucv.user_id = users.id
+					ORDER BY
+						latest_ucv.last_seen_at DESC,
+						latest_ucv.id DESC
+					LIMIT 1
+				)
 			AND (
 				LOWER(TRIM(ucv.version)) = ANY($%d)
 				OR LOWER(

--- a/backend/db/app_user.go
+++ b/backend/db/app_user.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/SFLuv/app/backend/structs"
@@ -146,11 +147,77 @@ func (a *AppDB) UpdateUserRole(ctx context.Context, userId string, role string, 
 	return nil
 }
 
-func (a *AppDB) GetUsers(ctx context.Context, page int, count int) ([]*structs.User, error) {
+func normalizeUserVersionFilters(versionFilters []string) []string {
+	normalized := []string{}
+	seen := map[string]struct{}{}
+	for _, raw := range versionFilters {
+		for _, value := range strings.Split(raw, ",") {
+			trimmed := strings.ToLower(strings.TrimSpace(value))
+			if trimmed == "" {
+				continue
+			}
+			if _, exists := seen[trimmed]; exists {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			normalized = append(normalized, trimmed)
+		}
+	}
+	return normalized
+}
+
+func appendUserListFilters(where []string, args []any, search string, versionFilters []string) ([]string, []any) {
+	if trimmed := strings.TrimSpace(search); trimmed != "" {
+		args = append(args, "%"+strings.ToLower(trimmed)+"%")
+		param := len(args)
+		where = append(where, fmt.Sprintf(`(
+			LOWER(id) LIKE $%d
+			OR LOWER(COALESCE(contact_email, '')) LIKE $%d
+			OR LOWER(COALESCE(contact_phone, '')) LIKE $%d
+			OR LOWER(COALESCE(contact_name, '')) LIKE $%d
+			OR LOWER(primary_wallet_address) LIKE $%d
+		)`, param, param, param, param, param))
+	}
+
+	versions := normalizeUserVersionFilters(versionFilters)
+	if len(versions) > 0 {
+		args = append(args, versions)
+		param := len(args)
+		where = append(where, fmt.Sprintf(`EXISTS (
+			SELECT
+				1
+			FROM
+				user_client_versions ucv
+			WHERE
+				ucv.user_id = users.id
+			AND (
+				LOWER(TRIM(ucv.version)) = ANY($%d)
+				OR LOWER(
+					CASE
+						WHEN TRIM(ucv.version) = '' THEN 'unknown'
+						WHEN TRIM(ucv.build) <> '' THEN TRIM(ucv.version) || ' (' || TRIM(ucv.build) || ')'
+						ELSE TRIM(ucv.version)
+					END
+				) = ANY($%d)
+				OR LOWER(TRIM(ucv.version) || ':' || TRIM(ucv.build)) = ANY($%d)
+			)
+		)`, param, param, param))
+	}
+
+	return where, args
+}
+
+func (a *AppDB) GetUsers(ctx context.Context, page int, count int, search string, versionFilters []string) ([]*structs.User, error) {
 	var users []*structs.User
 	offset := page * count
+	where := []string{"active = TRUE"}
+	args := []any{}
+	where, args = appendUserListFilters(where, args, search, versionFilters)
+	args = append(args, count, offset)
+	limitParam := len(args) - 1
+	offsetParam := len(args)
 
-	rows, err := a.db.Query(ctx, `
+	rows, err := a.db.Query(ctx, fmt.Sprintf(`
 		SELECT
 			id,
 			is_admin,
@@ -167,6 +234,7 @@ func (a *AppDB) GetUsers(ctx context.Context, page int, count int) ([]*structs.U
 			contact_name,
 			primary_wallet_address,
 			paypal_eth,
+			last_redemption,
 			accepted_privacy_policy,
 			accepted_privacy_policy_at,
 			privacy_policy_version,
@@ -176,10 +244,10 @@ func (a *AppDB) GetUsers(ctx context.Context, page int, count int) ([]*structs.U
 		FROM
 			users
 		WHERE
-			active = TRUE
-		LIMIT $1
-		OFFSET $2;
-	`, count, offset)
+			%s
+		LIMIT $%d
+		OFFSET $%d;
+	`, strings.Join(where, "\n\t\tAND "), limitParam, offsetParam), args...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting users: %s", err)
 	}
@@ -204,6 +272,7 @@ func (a *AppDB) GetUsers(ctx context.Context, page int, count int) ([]*structs.U
 			&user.Name,
 			&user.PrimaryWalletAddress,
 			&user.PayPalEth,
+			&user.LastRedemption,
 			&user.AcceptedPrivacyPolicy,
 			&user.AcceptedPrivacyPolicyAt,
 			&user.PrivacyPolicyVersion,
@@ -221,16 +290,20 @@ func (a *AppDB) GetUsers(ctx context.Context, page int, count int) ([]*structs.U
 	return users, nil
 }
 
-func (a *AppDB) CountUsers(ctx context.Context) (int, error) {
+func (a *AppDB) CountUsers(ctx context.Context, search string, versionFilters []string) (int, error) {
 	var total int
-	err := a.db.QueryRow(ctx, `
+	where := []string{"active = TRUE"}
+	args := []any{}
+	where, args = appendUserListFilters(where, args, search, versionFilters)
+
+	err := a.db.QueryRow(ctx, fmt.Sprintf(`
 		SELECT
 			COUNT(*)
 		FROM
 			users
 		WHERE
-			active = TRUE;
-	`).Scan(&total)
+			%s;
+	`, strings.Join(where, "\n\t\tAND ")), args...).Scan(&total)
 	if err != nil {
 		return 0, fmt.Errorf("error counting users: %s", err)
 	}

--- a/backend/handlers/app.go
+++ b/backend/handlers/app.go
@@ -50,4 +50,5 @@ func (a *AppService) RecordAnalyticsUserActivity(ctx context.Context, userID str
 	if err := a.db.RecordAnalyticsUserActivity(ctx, userID, platform, time.Now().UTC()); err != nil && a.logger != nil {
 		a.logger.Logf("error recording analytics user activity for %s: %s", userID, err)
 	}
+	a.recordClientVersionObservation(ctx, userID, "authenticated_request", r)
 }

--- a/backend/handlers/app_admin.go
+++ b/backend/handlers/app_admin.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/SFLuv/app/backend/structs"
@@ -35,31 +36,56 @@ func (a *AppService) GetUsers(w http.ResponseWriter, r *http.Request) {
 	if err != nil || count <= 0 || count > 500 {
 		count = 100
 	}
+	search := strings.TrimSpace(params.Get("search"))
+	versionFilters := append([]string{}, params["version"]...)
+	versionFilters = append(versionFilters, params["versions"]...)
 
-	users, err := a.db.GetUsers(r.Context(), page, count)
+	users, err := a.db.GetUsers(r.Context(), page, count, search, versionFilters)
 	if err != nil {
 		a.logger.Logf("error getting users: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	total, err := a.db.CountUsers(r.Context())
+	if err := a.db.AttachClientVersionDevices(r.Context(), users); err != nil {
+		a.logger.Logf("error attaching client version devices to users: %s", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	total, err := a.db.CountUsers(r.Context(), search, versionFilters)
 	if err != nil {
 		a.logger.Logf("error counting users: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
+	versionOptions, err := a.db.GetClientVersionFilterOptions(r.Context())
+	if err != nil {
+		a.logger.Logf("error getting client version filter options: %s", err)
+		versionOptions = []string{}
+	}
+
+	versionCounts, err := a.db.GetClientVersionUserCounts(r.Context())
+	if err != nil {
+		a.logger.Logf("error getting client version user counts: %s", err)
+		versionCounts = []*structs.ClientVersionUserCount{}
+	}
+
 	response := struct {
-		Users []*structs.User `json:"users"`
-		Total int             `json:"total"`
-		Page  int             `json:"page"`
-		Count int             `json:"count"`
+		Users                []*structs.User                   `json:"users"`
+		Total                int                               `json:"total"`
+		Page                 int                               `json:"page"`
+		Count                int                               `json:"count"`
+		ClientVersionOptions []string                          `json:"client_version_options"`
+		ClientVersionCounts  []*structs.ClientVersionUserCount `json:"client_version_counts"`
 	}{
-		Users: users,
-		Total: total,
-		Page:  page,
-		Count: count,
+		Users:                users,
+		Total:                total,
+		Page:                 page,
+		Count:                count,
+		ClientVersionOptions: versionOptions,
+		ClientVersionCounts:  versionCounts,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/backend/handlers/app_client_version_tracking.go
+++ b/backend/handlers/app_client_version_tracking.go
@@ -16,9 +16,10 @@ const (
 	clientVersionHeader  = "X-SFLUV-Client-Version"
 	clientBuildHeader    = "X-SFLUV-Client-Build"
 
-	legacyMobileClientVersion = "1.0.0"
-	legacyMobileClientBuild   = "1"
-	outdatedMobileClientBody  = "Client version out of date, please update your SFLuv app."
+	legacyMobileClientBlockEnvKey = "CLIENT_VERSION_LEGACY_BLOCK_ENABLED"
+	legacyMobileClientVersion     = "1.0.0"
+	legacyMobileClientBuild       = "1"
+	outdatedMobileClientBody      = "Client version out of date, please update your SFLuv app."
 )
 
 func parseClientBuildNumber(build string) int {
@@ -102,6 +103,10 @@ func isLikelyLegacyMobileClient(r *http.Request) bool {
 	}
 
 	return false
+}
+
+func legacyMobileClientBlockEnabled() bool {
+	return envBool(legacyMobileClientBlockEnvKey, true)
 }
 
 func (a *AppService) recordClientVersionObservation(ctx context.Context, userID string, source string, r *http.Request) {

--- a/backend/handlers/app_client_version_tracking.go
+++ b/backend/handlers/app_client_version_tracking.go
@@ -1,0 +1,163 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/SFLuv/app/backend/structs"
+)
+
+const (
+	clientPlatformHeader = "X-SFLUV-Client-Platform"
+	clientVersionHeader  = "X-SFLUV-Client-Version"
+	clientBuildHeader    = "X-SFLUV-Client-Build"
+
+	legacyMobileClientVersion = "1.0.0"
+	legacyMobileClientBuild   = "1"
+	outdatedMobileClientBody  = "Client version out of date, please update your SFLuv app."
+)
+
+func parseClientBuildNumber(build string) int {
+	parsed, err := strconv.Atoi(strings.TrimSpace(build))
+	if err != nil || parsed < 0 {
+		return 0
+	}
+	return parsed
+}
+
+func clientKeyForObservation(userID string, platform string) string {
+	if strings.TrimSpace(userID) == "" {
+		return ""
+	}
+	normalizedPlatform := strings.ToLower(strings.TrimSpace(platform))
+	if normalizedPlatform == "" {
+		normalizedPlatform = "unknown"
+	}
+	return fmt.Sprintf("user:%s:platform:%s", strings.TrimSpace(userID), normalizedPlatform)
+}
+
+func inferLegacyMobilePlatform(r *http.Request) string {
+	if r == nil {
+		return "mobile"
+	}
+	ua := strings.ToLower(r.UserAgent())
+	switch {
+	case strings.Contains(ua, "android"), strings.Contains(ua, "okhttp"):
+		return "android"
+	case strings.Contains(ua, "iphone"), strings.Contains(ua, "ipad"), strings.Contains(ua, "cfnetwork"), strings.Contains(ua, "darwin"):
+		return "ios"
+	default:
+		return "mobile"
+	}
+}
+
+func hasClientVersionHeaders(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	return strings.TrimSpace(r.Header.Get(clientPlatformHeader)) != "" ||
+		strings.TrimSpace(r.Header.Get(clientVersionHeader)) != "" ||
+		strings.TrimSpace(r.Header.Get(clientBuildHeader)) != ""
+}
+
+func isBrowserLikeRequest(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	return strings.TrimSpace(r.Header.Get("Origin")) != "" ||
+		strings.TrimSpace(r.Header.Get("Referer")) != "" ||
+		strings.TrimSpace(r.Header.Get("Sec-Fetch-Site")) != "" ||
+		strings.TrimSpace(r.Header.Get("Sec-Fetch-Mode")) != ""
+}
+
+func isLikelyLegacyMobileClient(r *http.Request) bool {
+	if r == nil || hasClientVersionHeaders(r) || isBrowserLikeRequest(r) {
+		return false
+	}
+
+	ua := strings.ToLower(r.UserAgent())
+	if ua == "" {
+		return false
+	}
+	mobileMarkers := []string{
+		"android",
+		"cfnetwork",
+		"darwin",
+		"expo",
+		"iphone",
+		"ipad",
+		"okhttp",
+		"react-native",
+		"reactnative",
+		"sfluv",
+	}
+	for _, marker := range mobileMarkers {
+		if strings.Contains(ua, marker) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (a *AppService) recordClientVersionObservation(ctx context.Context, userID string, source string, r *http.Request) {
+	if a == nil || a.db == nil || r == nil {
+		return
+	}
+
+	if strings.TrimSpace(userID) == "" {
+		return
+	}
+
+	platform := strings.ToLower(strings.TrimSpace(r.Header.Get(clientPlatformHeader)))
+	version := strings.TrimSpace(r.Header.Get(clientVersionHeader))
+	build := strings.TrimSpace(r.Header.Get(clientBuildHeader))
+	clientKey := clientKeyForObservation(userID, platform)
+	if clientKey == "" {
+		return
+	}
+	if platform == "" && version == "" && build == "" {
+		return
+	}
+
+	observation := structs.ClientVersionObservation{
+		UserId:      strings.TrimSpace(userID),
+		ClientKey:   clientKey,
+		Platform:    platform,
+		Version:     strings.TrimSpace(version),
+		Build:       strings.TrimSpace(build),
+		BuildNumber: parseClientBuildNumber(build),
+		UserAgent:   r.UserAgent(),
+		Source:      strings.TrimSpace(source),
+		SeenAt:      time.Now().UTC(),
+	}
+	if err := a.db.RecordClientVersionObservation(ctx, observation); err != nil && a.logger != nil {
+		a.logger.Logf("error recording client version observation for %s: %s", userID, err)
+	}
+}
+
+func (a *AppService) recordLegacyMobileClientObservation(ctx context.Context, userID string, source string, r *http.Request) {
+	if a == nil || a.db == nil || strings.TrimSpace(userID) == "" {
+		return
+	}
+	platform := inferLegacyMobilePlatform(r)
+	observation := structs.ClientVersionObservation{
+		UserId:         strings.TrimSpace(userID),
+		ClientKey:      clientKeyForObservation(userID, platform),
+		Platform:       platform,
+		Version:        legacyMobileClientVersion,
+		Build:          legacyMobileClientBuild,
+		BuildNumber:    parseClientBuildNumber(legacyMobileClientBuild),
+		UserAgent:      r.UserAgent(),
+		Source:         strings.TrimSpace(source),
+		LegacyInferred: true,
+		SeenAt:         time.Now().UTC(),
+	}
+	if err := a.db.RecordClientVersionObservation(ctx, observation); err != nil && a.logger != nil {
+		a.logger.Logf("error recording inferred legacy client for %s: %s", userID, err)
+	}
+}

--- a/backend/handlers/app_client_version_tracking.go
+++ b/backend/handlers/app_client_version_tracking.go
@@ -84,6 +84,12 @@ func isLikelyLegacyMobileClient(r *http.Request) bool {
 	if ua == "" {
 		return false
 	}
+	// Browsers (and WebViews) always identify as Mozilla; the released native
+	// app uses CFNetwork/Darwin (iOS) or okhttp (Android) user agents, so any
+	// Mozilla UA is web traffic even when Origin/Referer/Sec-Fetch are absent.
+	if strings.Contains(ua, "mozilla") {
+		return false
+	}
 	mobileMarkers := []string{
 		"android",
 		"cfnetwork",

--- a/backend/handlers/app_client_version_tracking_test.go
+++ b/backend/handlers/app_client_version_tracking_test.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestIsLikelyLegacyMobileClient(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "/users", nil)
+	if err != nil {
+		t.Fatalf("error creating request: %s", err)
+	}
+	req.Header.Set("User-Agent", "SFLuv/1 CFNetwork/1496.0.7 Darwin/23.5.0")
+
+	if !isLikelyLegacyMobileClient(req) {
+		t.Fatal("expected native mobile request without client headers to be treated as legacy")
+	}
+
+	req.Header.Set(clientVersionHeader, "1.0.1")
+	if isLikelyLegacyMobileClient(req) {
+		t.Fatal("expected request with client version header not to be treated as legacy")
+	}
+
+	req.Header.Del(clientVersionHeader)
+	req.Header.Set("Origin", "https://app.sfluv.org")
+	if isLikelyLegacyMobileClient(req) {
+		t.Fatal("expected browser-like request not to be treated as legacy mobile")
+	}
+}
+
+func TestLegacyMobileClientBlockEnabled(t *testing.T) {
+	t.Setenv(legacyMobileClientBlockEnvKey, "")
+	if !legacyMobileClientBlockEnabled() {
+		t.Fatal("expected legacy mobile block to default on")
+	}
+
+	t.Setenv(legacyMobileClientBlockEnvKey, "false")
+	if legacyMobileClientBlockEnabled() {
+		t.Fatal("expected legacy mobile block to be disabled by false env value")
+	}
+
+	t.Setenv(legacyMobileClientBlockEnvKey, "1")
+	if !legacyMobileClientBlockEnabled() {
+		t.Fatal("expected legacy mobile block to accept truthy env value")
+	}
+}

--- a/backend/handlers/app_client_version_tracking_test.go
+++ b/backend/handlers/app_client_version_tracking_test.go
@@ -28,6 +28,54 @@ func TestIsLikelyLegacyMobileClient(t *testing.T) {
 	}
 }
 
+func TestIsLikelyLegacyMobileClientUserAgents(t *testing.T) {
+	cases := []struct {
+		name      string
+		userAgent string
+		legacy    bool
+	}{
+		{
+			name:      "legacy ios native client",
+			userAgent: "SFLuv/1 CFNetwork/1496.0.7 Darwin/23.5.0",
+			legacy:    true,
+		},
+		{
+			name:      "legacy android native client",
+			userAgent: "okhttp/4.9.2",
+			legacy:    true,
+		},
+		{
+			name:      "ios safari without origin or sec-fetch headers",
+			userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 15_8 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6 Mobile/15E148 Safari/604.1",
+			legacy:    false,
+		},
+		{
+			name:      "android chrome without origin or sec-fetch headers",
+			userAgent: "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Mobile Safari/537.36",
+			legacy:    false,
+		},
+		{
+			name:      "desktop safari without origin or sec-fetch headers",
+			userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15",
+			legacy:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "/users", nil)
+			if err != nil {
+				t.Fatalf("error creating request: %s", err)
+			}
+			req.Header.Set("User-Agent", tc.userAgent)
+
+			if got := isLikelyLegacyMobileClient(req); got != tc.legacy {
+				t.Fatalf("isLikelyLegacyMobileClient = %t, expected %t for %q", got, tc.legacy, tc.userAgent)
+			}
+		})
+	}
+}
+
 func TestLegacyMobileClientBlockEnabled(t *testing.T) {
 	t.Setenv(legacyMobileClientBlockEnvKey, "")
 	if !legacyMobileClientBlockEnabled() {

--- a/backend/handlers/app_policy.go
+++ b/backend/handlers/app_policy.go
@@ -41,6 +41,8 @@ func (a *AppService) GetUserPolicyStatus(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	a.recordClientVersionObservation(r.Context(), *userDid, "user_policy_status", r)
+
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(status)
 }
@@ -86,6 +88,8 @@ func (a *AppService) AcceptUserPolicies(w http.ResponseWriter, r *http.Request) 
 		_, _ = w.Write([]byte("inactive users must reactivate before accepting policies"))
 		return
 	}
+
+	a.recordClientVersionObservation(r.Context(), *userDid, "user_policy_accept", r)
 
 	status, err := a.db.AcceptUserPolicies(r.Context(), *userDid, req.MailingListOptIn, time.Now().UTC())
 	if err != nil {

--- a/backend/handlers/app_user.go
+++ b/backend/handlers/app_user.go
@@ -34,6 +34,8 @@ func (a *AppService) AddUser(w http.ResponseWriter, r *http.Request) {
 		a.logger.Logf("error syncing Privy linked emails for new user %s: %s", *userDid, err)
 	}
 
+	a.recordClientVersionObservation(r.Context(), *userDid, "user_create", r)
+
 	w.WriteHeader(http.StatusCreated)
 }
 
@@ -52,6 +54,14 @@ func (a *AppService) GetUserAuthed(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		a.logger.Logf("error getting user by id %s: %s", *userDid, err.Error())
 		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if isLikelyLegacyMobileClient(r) {
+		a.recordLegacyMobileClientObservation(r.Context(), *userDid, "legacy_users_get_block", r)
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusUpgradeRequired)
+		_, _ = w.Write([]byte(outdatedMobileClientBody))
 		return
 	}
 
@@ -197,7 +207,7 @@ func (a *AppService) UpdateUserPayPalEth(w http.ResponseWriter, r *http.Request)
 
 	err = a.db.UpdateUserPayPalEth(r.Context(), *userDid, body)
 	if err != nil {
-		a.logger.Logf("error updating user paypal address for user: " + *userDid)
+		a.logger.Logf("error updating user paypal address for user: %s", *userDid)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/backend/handlers/app_user.go
+++ b/backend/handlers/app_user.go
@@ -57,7 +57,7 @@ func (a *AppService) GetUserAuthed(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if isLikelyLegacyMobileClient(r) {
+	if legacyMobileClientBlockEnabled() && isLikelyLegacyMobileClient(r) {
 		a.recordLegacyMobileClientObservation(r.Context(), *userDid, "legacy_users_get_block", r)
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusUpgradeRequired)

--- a/backend/router/router.go
+++ b/backend/router/router.go
@@ -91,7 +91,7 @@ func New(s *handlers.BotService, a *handlers.AppService, p *handlers.PonderServi
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   allowedOrigins(),
 		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "Access-Token", "X-Admin-Key", "X-SFLUV-Client-Platform", "X-SFLUV-Client-Version", "X-SFLUV-Client-Build"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "Access-Token", "X-Admin-Key", "X-SFLUV-Client-Platform", "X-SFLUV-Client-Version", "X-SFLUV-Client-Build", "X-SFLUV-Client-Installation"},
 		ExposedHeaders:   []string{"Link", "X-SFLUV-Auth-Reason"},
 		AllowCredentials: false,
 		MaxAge:           300,

--- a/backend/structs/app_user.go
+++ b/backend/structs/app_user.go
@@ -3,29 +3,65 @@ package structs
 import "time"
 
 type User struct {
-	Id                       string     `json:"id"`
-	Exists                   bool       `json:"exists"`
-	IsAdmin                  bool       `json:"is_admin"`
-	IsMerchant               bool       `json:"is_merchant"`
-	IsOrganizer              bool       `json:"is_organizer"`
-	IsImprover               bool       `json:"is_improver"`
-	IsProposer               bool       `json:"is_proposer"`
-	IsVoter                  bool       `json:"is_voter"`
-	IsIssuer                 bool       `json:"is_issuer"`
-	IsSupervisor             bool       `json:"is_supervisor"`
-	IsAffiliate              bool       `json:"is_affiliate"`
-	Email                    *string    `json:"contact_email"`
-	Phone                    *string    `json:"contact_phone"`
-	Name                     *string    `json:"contact_name"`
-	PrimaryWalletAddress     string     `json:"primary_wallet_address"`
-	PayPalEth                string     `json:"paypal_eth"`
-	LastRedemption           int        `json:"last_redemption"`
-	AcceptedPrivacyPolicy    bool       `json:"accepted_privacy_policy"`
-	AcceptedPrivacyPolicyAt  *time.Time `json:"accepted_privacy_policy_at,omitempty"`
-	PrivacyPolicyVersion     string     `json:"privacy_policy_version"`
-	MailingListOptIn         bool       `json:"mailing_list_opt_in"`
-	MailingListOptInAt       *time.Time `json:"mailing_list_opt_in_at,omitempty"`
-	MailingListPolicyVersion string     `json:"mailing_list_policy_version"`
+	Id                       string                 `json:"id"`
+	Exists                   bool                   `json:"exists"`
+	IsAdmin                  bool                   `json:"is_admin"`
+	IsMerchant               bool                   `json:"is_merchant"`
+	IsOrganizer              bool                   `json:"is_organizer"`
+	IsImprover               bool                   `json:"is_improver"`
+	IsProposer               bool                   `json:"is_proposer"`
+	IsVoter                  bool                   `json:"is_voter"`
+	IsIssuer                 bool                   `json:"is_issuer"`
+	IsSupervisor             bool                   `json:"is_supervisor"`
+	IsAffiliate              bool                   `json:"is_affiliate"`
+	Email                    *string                `json:"contact_email"`
+	Phone                    *string                `json:"contact_phone"`
+	Name                     *string                `json:"contact_name"`
+	PrimaryWalletAddress     string                 `json:"primary_wallet_address"`
+	PayPalEth                string                 `json:"paypal_eth"`
+	LastRedemption           int                    `json:"last_redemption"`
+	AcceptedPrivacyPolicy    bool                   `json:"accepted_privacy_policy"`
+	AcceptedPrivacyPolicyAt  *time.Time             `json:"accepted_privacy_policy_at,omitempty"`
+	PrivacyPolicyVersion     string                 `json:"privacy_policy_version"`
+	MailingListOptIn         bool                   `json:"mailing_list_opt_in"`
+	MailingListOptInAt       *time.Time             `json:"mailing_list_opt_in_at,omitempty"`
+	MailingListPolicyVersion string                 `json:"mailing_list_policy_version"`
+	ClientDevices            []*ClientVersionDevice `json:"client_devices,omitempty"`
+}
+
+type ClientVersionDevice struct {
+	Id             int64     `json:"id"`
+	UserId         string    `json:"user_id,omitempty"`
+	Platform       string    `json:"platform"`
+	Version        string    `json:"version"`
+	Build          string    `json:"build"`
+	VersionLabel   string    `json:"version_label"`
+	Source         string    `json:"source"`
+	LegacyInferred bool      `json:"legacy_inferred"`
+	FirstSeenAt    time.Time `json:"first_seen_at"`
+	LastSeenAt     time.Time `json:"last_seen_at"`
+}
+
+type ClientVersionUserCount struct {
+	VersionLabel   string `json:"version_label"`
+	Version        string `json:"version"`
+	Build          string `json:"build"`
+	UserCount      int    `json:"user_count"`
+	LegacyInferred bool   `json:"legacy_inferred"`
+	Unknown        bool   `json:"unknown"`
+}
+
+type ClientVersionObservation struct {
+	UserId         string
+	ClientKey      string
+	Platform       string
+	Version        string
+	Build          string
+	BuildNumber    int
+	UserAgent      string
+	Source         string
+	LegacyInferred bool
+	SeenAt         time.Time
 }
 
 const (

--- a/backend/test/users_controllers_test.go
+++ b/backend/test/users_controllers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SFLuv/app/backend/structs"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -101,6 +102,74 @@ func ModuleGetUsersController(t *testing.T) {
 		if *user.Email != *TEST_USERS[n].Email {
 			t.Fatalf("email %s does not match expected %s", *user.Email, *TEST_USERS[n].Email)
 		}
+	}
+
+	older := time.Now().UTC().Add(-2 * time.Hour)
+	if err := AppDb.RecordClientVersionObservation(ctx, structs.ClientVersionObservation{
+		UserId:         TEST_USER_1.Id,
+		ClientKey:      "test:user-1:platform:mobile",
+		Platform:       "mobile",
+		Version:        "1.0.0",
+		Build:          "1",
+		BuildNumber:    1,
+		LegacyInferred: true,
+		SeenAt:         older,
+	}); err != nil {
+		t.Fatalf("error recording older user 1 client version: %s", err)
+	}
+	if err := AppDb.RecordClientVersionObservation(ctx, structs.ClientVersionObservation{
+		UserId:      TEST_USER_1.Id,
+		ClientKey:   "test:user-1:platform:ios",
+		Platform:    "ios",
+		Version:     "2.0.0",
+		Build:       "7",
+		BuildNumber: 7,
+		SeenAt:      older.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("error recording latest user 1 client version: %s", err)
+	}
+	if err := AppDb.RecordClientVersionObservation(ctx, structs.ClientVersionObservation{
+		UserId:         TEST_USER_2.Id,
+		ClientKey:      "test:user-2:platform:mobile",
+		Platform:       "mobile",
+		Version:        "1.0.0",
+		Build:          "1",
+		BuildNumber:    1,
+		LegacyInferred: true,
+		SeenAt:         older.Add(30 * time.Minute),
+	}); err != nil {
+		t.Fatalf("error recording user 2 client version: %s", err)
+	}
+
+	oldVersionUsers, err := AppDb.GetUsers(ctx, 0, 10, "", []string{"1.0.0 (1)"})
+	if err != nil {
+		t.Fatalf("error filtering users by old client version: %s", err)
+	}
+	if len(oldVersionUsers) != 1 || oldVersionUsers[0].Id != TEST_USER_2.Id {
+		t.Fatalf("expected old-version filter to include only %s, got %#v", TEST_USER_2.Id, oldVersionUsers)
+	}
+
+	newVersionUsers, err := AppDb.GetUsers(ctx, 0, 10, "", []string{"2.0.0 (7)"})
+	if err != nil {
+		t.Fatalf("error filtering users by new client version: %s", err)
+	}
+	if len(newVersionUsers) != 1 || newVersionUsers[0].Id != TEST_USER_1.Id {
+		t.Fatalf("expected new-version filter to include only %s, got %#v", TEST_USER_1.Id, newVersionUsers)
+	}
+
+	counts, err := AppDb.GetClientVersionUserCounts(ctx)
+	if err != nil {
+		t.Fatalf("error getting client version user counts: %s", err)
+	}
+	countByLabel := map[string]int{}
+	for _, count := range counts {
+		countByLabel[count.VersionLabel] = count.UserCount
+	}
+	if countByLabel["1.0.0 (1)"] != 1 {
+		t.Fatalf("expected one current old-version user, got %d", countByLabel["1.0.0 (1)"])
+	}
+	if countByLabel["2.0.0 (7)"] != 1 {
+		t.Fatalf("expected one current new-version user, got %d", countByLabel["2.0.0 (7)"])
 	}
 }
 

--- a/backend/test/users_controllers_test.go
+++ b/backend/test/users_controllers_test.go
@@ -78,7 +78,7 @@ func ModuleGetUsersController(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	users, err := AppDb.GetUsers(ctx, 0, 2)
+	users, err := AppDb.GetUsers(ctx, 0, 2, "", nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -90,7 +90,7 @@ import { WorkflowDetailsModal } from "@/components/workflows/workflow-details-mo
 import { AdminAnalyticsPanel } from "@/components/admin/admin-analytics-panel"
 import EventCard from "@/components/events/event-card"
 import type { W9Submission } from "@/types/w9"
-import type { UserResponse } from "@/types/server"
+import type { ClientVersionUserCountResponse, UserResponse } from "@/types/server"
 
 // Mock PayPal accounts
 const mockPaypalAccounts = [
@@ -134,6 +134,8 @@ type AdminUsersResponse = {
   total: number
   page: number
   count: number
+  client_version_options?: string[]
+  client_version_counts?: ClientVersionUserCountResponse[]
 }
 
 type AdminUserRoleFlag =
@@ -170,6 +172,28 @@ const formatAdminUserDateTime = (value?: string | null): string => {
   if (Number.isNaN(date.getTime())) return "Not set"
   return date.toLocaleString()
 }
+
+const splitAdminUserVersionFilter = (value: string): string[] =>
+  value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+
+const getAdminUserLatestClientDevice = (adminUser: UserResponse) =>
+  [...(adminUser.client_devices || [])].sort((a, b) => {
+    const aTime = new Date(a.last_seen_at).getTime()
+    const bTime = new Date(b.last_seen_at).getTime()
+    return (Number.isFinite(bTime) ? bTime : 0) - (Number.isFinite(aTime) ? aTime : 0)
+  })[0]
+
+const getAdminUserClientVersionSummary = (adminUser: UserResponse): string => {
+  const latest = getAdminUserLatestClientDevice(adminUser)
+  if (!latest) return "Unknown"
+  return latest.version_label || latest.version || "Unknown"
+}
+
+const getAdminUsersVersionFilterValue = (count: ClientVersionUserCountResponse): string =>
+  count.unknown ? "" : count.version_label || count.version || ""
 
 const maxCredentialBadgeUploadBytes = 2 * 1024 * 1024
 const maxCredentialBadgeUploadLabel = "2MB"
@@ -323,9 +347,15 @@ export default function AdminPage() {
   const [adminUsersTotal, setAdminUsersTotal] = useState<number>(0)
   const [adminUsersPage, setAdminUsersPage] = useState<number>(readQueryNumber("users_page", 0))
   const [adminUsersCount] = useState<number>(20)
+  const [adminUsersSearch, setAdminUsersSearch] = useState<string>(readQueryText("users_search", ""))
+  const [adminUsersVersionFilter, setAdminUsersVersionFilter] = useState<string>(readQueryText("users_versions", ""))
+  const [adminUsersVersionOptions, setAdminUsersVersionOptions] = useState<string[]>([])
+  const [adminUsersVersionCounts, setAdminUsersVersionCounts] = useState<ClientVersionUserCountResponse[]>([])
   const [adminUsersLoading, setAdminUsersLoading] = useState<boolean>(false)
   const [adminUsersError, setAdminUsersError] = useState<string>("")
   const [adminEmailExporting, setAdminEmailExporting] = useState<boolean>(false)
+  const [selectedAdminUser, setSelectedAdminUser] = useState<UserResponse | null>(null)
+  const [adminUserModalOpen, setAdminUserModalOpen] = useState<boolean>(false)
 
   // Events
   const [events, setEvents] = useState<Event[]>([])
@@ -632,6 +662,11 @@ export default function AdminPage() {
   const canLoadNextAffiliatePage = affiliates.length >= 20
   const canLoadPreviousAdminUsersPage = adminUsersPage > 0
   const canLoadNextAdminUsersPage = (adminUsersPage + 1) * adminUsersCount < adminUsersTotal
+  const selectedAdminUserVersions = splitAdminUserVersionFilter(adminUsersVersionFilter)
+  const adminUsersVersionCountsTotal = adminUsersVersionCounts.reduce(
+    (sum, count) => sum + (Number.isFinite(count.user_count) ? count.user_count : 0),
+    0,
+  )
 
   const filteredProposers = useMemo(() => {
     if (proposerStatusFilter === "all") return proposers
@@ -715,23 +750,33 @@ export default function AdminPage() {
       })
   }, [adminWorkflows])
 
-  const getAdminUsers = async (page = adminUsersPage) => {
+  const getAdminUsers = async (
+    page = adminUsersPage,
+    search = adminUsersSearch,
+    versionFilter = adminUsersVersionFilter,
+  ) => {
     setAdminUsersLoading(true)
     try {
       const params = new URLSearchParams({
         page: String(page),
         count: String(adminUsersCount),
       })
+      if (search.trim()) params.set("search", search.trim())
+      splitAdminUserVersionFilter(versionFilter).forEach((version) => params.append("version", version))
       const res = await authFetch(`/admin/users?${params}`)
       if (!res.ok) throw new Error()
       const data = await res.json()
       if (Array.isArray(data)) {
         setAdminUsers(data)
         setAdminUsersTotal(page * adminUsersCount + data.length)
+        setAdminUsersVersionOptions([])
+        setAdminUsersVersionCounts([])
       } else {
         const response = data as AdminUsersResponse
         setAdminUsers(response.users || [])
         setAdminUsersTotal(response.total || 0)
+        setAdminUsersVersionOptions(response.client_version_options || [])
+        setAdminUsersVersionCounts(response.client_version_counts || [])
       }
       setAdminUsersError("")
     } catch {
@@ -739,6 +784,18 @@ export default function AdminPage() {
     } finally {
       setAdminUsersLoading(false)
     }
+  }
+
+  const toggleAdminUsersVersionFilter = (version: string) => {
+    const normalized = version.trim()
+    if (!normalized) return
+    const current = splitAdminUserVersionFilter(adminUsersVersionFilter)
+    const exists = current.some((entry) => entry.toLowerCase() === normalized.toLowerCase())
+    const next = exists
+      ? current.filter((entry) => entry.toLowerCase() !== normalized.toLowerCase())
+      : [...current, normalized]
+    setAdminUsersPage(0)
+    setAdminUsersVersionFilter(next.join(", "))
   }
 
   const exportAdminEmailList = async () => {
@@ -1532,6 +1589,10 @@ export default function AdminPage() {
 
     const nextAdminUsersPage = readQueryNumber("users_page", 0)
     if (nextAdminUsersPage !== adminUsersPage) setAdminUsersPage(nextAdminUsersPage)
+    const nextAdminUsersSearch = readQueryText("users_search", "")
+    if (nextAdminUsersSearch !== adminUsersSearch) setAdminUsersSearch(nextAdminUsersSearch)
+    const nextAdminUsersVersions = readQueryText("users_versions", "")
+    if (nextAdminUsersVersions !== adminUsersVersionFilter) setAdminUsersVersionFilter(nextAdminUsersVersions)
 
     const nextMerchantSearch = readQueryText("merchant_search", "")
     if (nextMerchantSearch !== merchantSearch) setMerchantSearch(nextMerchantSearch)
@@ -1599,6 +1660,10 @@ export default function AdminPage() {
 
     if (adminUsersPage > 0) params.set("users_page", String(adminUsersPage))
     else params.delete("users_page")
+    if (adminUsersSearch) params.set("users_search", adminUsersSearch)
+    else params.delete("users_search")
+    if (adminUsersVersionFilter) params.set("users_versions", adminUsersVersionFilter)
+    else params.delete("users_versions")
 
     if (merchantSearch) params.set("merchant_search", merchantSearch)
     else params.delete("merchant_search")
@@ -1665,6 +1730,8 @@ export default function AdminPage() {
   }, [
     activeTab,
     adminUsersPage,
+    adminUsersSearch,
+    adminUsersVersionFilter,
     merchantSearch,
     merchantStatusFilter,
     eventsSearch,
@@ -1764,6 +1831,8 @@ export default function AdminPage() {
     activeTab,
     status,
     adminUsersPage,
+    adminUsersSearch,
+    adminUsersVersionFilter,
     affiliateSearch,
     affiliatePage,
     proposerSearch,
@@ -2889,6 +2958,111 @@ export default function AdminPage() {
             </div>
           )}
 
+          <Dialog
+            open={adminUserModalOpen}
+            onOpenChange={(open) => {
+              setAdminUserModalOpen(open)
+              if (!open) setSelectedAdminUser(null)
+            }}
+          >
+            <DialogContent className="w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] max-h-[90vh] overflow-y-auto sm:max-w-3xl">
+              <DialogHeader>
+                <DialogTitle>{selectedAdminUser?.contact_name || "User"}</DialogTitle>
+                <DialogDescription className="break-all font-mono text-xs">
+                  {selectedAdminUser?.id}
+                </DialogDescription>
+              </DialogHeader>
+              {selectedAdminUser && (
+                <div className="space-y-5">
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="space-y-1">
+                      <p className="text-xs font-medium uppercase text-muted-foreground">Contact</p>
+                      <p className="break-all text-sm">{selectedAdminUser.contact_email || "No email on profile"}</p>
+                      <p className="text-sm text-muted-foreground">{selectedAdminUser.contact_phone || "No phone on profile"}</p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs font-medium uppercase text-muted-foreground">Primary wallet</p>
+                      <p className="break-all font-mono text-xs text-muted-foreground">
+                        {selectedAdminUser.primary_wallet_address || "No primary wallet"}
+                      </p>
+                    </div>
+                    <div className="space-y-2">
+                      <p className="text-xs font-medium uppercase text-muted-foreground">Roles</p>
+                      <div className="flex flex-wrap gap-1">
+                        {getAdminUserRoleLabels(selectedAdminUser).length === 0 ? (
+                          <Badge variant="outline">User</Badge>
+                        ) : (
+                          getAdminUserRoleLabels(selectedAdminUser).map((role) => (
+                            <Badge key={`modal-${selectedAdminUser.id}-${role}`} variant={role === "Admin" ? "default" : "secondary"}>
+                              {role}
+                            </Badge>
+                          ))
+                        )}
+                      </div>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs font-medium uppercase text-muted-foreground">Email opt-in</p>
+                      <Badge variant={selectedAdminUser.mailing_list_opt_in ? "default" : "outline"}>
+                        {selectedAdminUser.mailing_list_opt_in ? "Opted in" : "Not opted in"}
+                      </Badge>
+                      <p className="text-xs text-muted-foreground">
+                        {formatAdminUserDateTime(selectedAdminUser.mailing_list_opt_in_at)}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <h4 className="text-sm font-semibold">Client versions</h4>
+                      <Badge variant="outline">{selectedAdminUser.client_devices?.length || 0}</Badge>
+                    </div>
+                    {(selectedAdminUser.client_devices || []).length === 0 ? (
+                      <p className="rounded-md border px-3 py-6 text-center text-sm text-muted-foreground">
+                        No client version observations recorded.
+                      </p>
+                    ) : (
+                      <div className="overflow-x-auto rounded-md border">
+                        <table className="w-full min-w-[680px] text-sm">
+                          <thead className="bg-muted/60 text-left text-xs uppercase text-muted-foreground">
+                            <tr>
+                              <th className="px-3 py-2 font-medium">Platform</th>
+                              <th className="px-3 py-2 font-medium">Version</th>
+                              <th className="px-3 py-2 font-medium">Source</th>
+                              <th className="px-3 py-2 font-medium">First seen</th>
+                              <th className="px-3 py-2 font-medium">Last seen</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y">
+                            {(selectedAdminUser.client_devices || []).map((device) => (
+                              <tr key={device.id}>
+                                <td className="px-3 py-2 capitalize">{device.platform || "unknown"}</td>
+                                <td className="px-3 py-2">
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    <Badge variant={device.legacy_inferred ? "destructive" : "secondary"}>
+                                      {device.version_label || "Unknown"}
+                                    </Badge>
+                                    {device.legacy_inferred && <span className="text-xs text-muted-foreground">inferred</span>}
+                                  </div>
+                                </td>
+                                <td className="px-3 py-2 text-xs text-muted-foreground">{device.source || "unknown"}</td>
+                                <td className="px-3 py-2 text-xs text-muted-foreground">
+                                  {formatAdminUserDateTime(device.first_seen_at)}
+                                </td>
+                                <td className="px-3 py-2 text-xs text-muted-foreground">
+                                  {formatAdminUserDateTime(device.last_seen_at)}
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </DialogContent>
+          </Dialog>
+
           <Card>
             <CardHeader className="pb-4">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -2915,6 +3089,115 @@ export default function AdminPage() {
               </div>
             </CardHeader>
             <CardContent className="space-y-4">
+              <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(280px,360px)]">
+                <div className="space-y-2">
+                  <Label htmlFor="admin-users-search">Search users</Label>
+                  <div className="relative">
+                    <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                      id="admin-users-search"
+                      value={adminUsersSearch}
+                      onChange={(event) => {
+                        setAdminUsersPage(0)
+                        setAdminUsersSearch(event.target.value)
+                      }}
+                      className="pl-9"
+                      placeholder="Name, email, phone, wallet, DID"
+                    />
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="admin-users-version-filter">App versions</Label>
+                  <Input
+                    id="admin-users-version-filter"
+                    value={adminUsersVersionFilter}
+                    onChange={(event) => {
+                      setAdminUsersPage(0)
+                      setAdminUsersVersionFilter(event.target.value)
+                    }}
+                    placeholder="Version or build"
+                  />
+                </div>
+              </div>
+
+              {adminUsersVersionCounts.length > 0 && (
+                <div className="rounded-lg border bg-muted/20 p-4">
+                  <div className="mb-3 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <h4 className="text-sm font-semibold">App version breakdown</h4>
+                      <p className="text-xs text-muted-foreground">
+                        Latest recorded app version across {adminUsersVersionCountsTotal} active users
+                      </p>
+                    </div>
+                    <Badge variant="outline">{adminUsersVersionCounts.length} buckets</Badge>
+                  </div>
+                  <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                    {adminUsersVersionCounts.map((count) => {
+                      const filterValue = getAdminUsersVersionFilterValue(count)
+                      const selected = filterValue
+                        ? selectedAdminUserVersions.some((entry) => entry.toLowerCase() === filterValue.toLowerCase())
+                        : false
+                      return (
+                        <button
+                          key={`${count.version_label}-${count.unknown ? "unknown" : "known"}-${count.legacy_inferred ? "legacy" : "current"}`}
+                          type="button"
+                          disabled={!filterValue}
+                          onClick={() => filterValue && toggleAdminUsersVersionFilter(filterValue)}
+                          className={cn(
+                            "flex min-h-[72px] items-center justify-between gap-3 rounded-md border bg-background px-3 py-2 text-left transition-colors",
+                            filterValue ? "hover:bg-muted/60" : "cursor-default opacity-80",
+                            selected && "border-primary bg-primary/5",
+                          )}
+                        >
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-medium">
+                              {count.version_label || "Unknown / no version"}
+                            </p>
+                            <div className="mt-1 flex flex-wrap items-center gap-1">
+                              {count.legacy_inferred && <Badge variant="destructive">Inferred legacy</Badge>}
+                              {count.unknown && <Badge variant="outline">No backend version</Badge>}
+                            </div>
+                          </div>
+                          <span className="text-2xl font-semibold tabular-nums">{count.user_count}</span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                </div>
+              )}
+
+              <div className="flex flex-wrap items-center gap-2">
+                {adminUsersVersionOptions.map((version) => {
+                  const selected = selectedAdminUserVersions.some((entry) => entry.toLowerCase() === version.toLowerCase())
+                  return (
+                    <Button
+                      key={version}
+                      type="button"
+                      variant={selected ? "default" : "outline"}
+                      size="sm"
+                      onClick={() => toggleAdminUsersVersionFilter(version)}
+                    >
+                      {version}
+                    </Button>
+                  )
+                })}
+                {(adminUsersSearch || adminUsersVersionFilter) && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setAdminUsersPage(0)
+                      setAdminUsersSearch("")
+                      setAdminUsersVersionFilter("")
+                    }}
+                  >
+                    <X className="h-4 w-4" />
+                    Clear
+                  </Button>
+                )}
+              </div>
+
               <div className="text-sm text-muted-foreground">
                 Showing{" "}
                 {adminUsersTotal === 0
@@ -2936,19 +3219,22 @@ export default function AdminPage() {
                 </div>
               ) : (
                 <div className="overflow-x-auto rounded-lg border">
-                  <table className="w-full min-w-[920px] text-sm">
+                  <table className="w-full min-w-[1100px] text-sm">
                     <thead className="bg-muted/60 text-left text-xs uppercase text-muted-foreground">
                       <tr>
                         <th className="px-4 py-3 font-medium">User</th>
                         <th className="px-4 py-3 font-medium">Contact</th>
                         <th className="px-4 py-3 font-medium">Roles</th>
+                        <th className="px-4 py-3 font-medium">App version</th>
                         <th className="px-4 py-3 font-medium">Email opt-in</th>
                         <th className="px-4 py-3 font-medium">Primary wallet</th>
+                        <th className="px-4 py-3 font-medium">Actions</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y">
                       {adminUsers.map((adminUser) => {
                         const roleLabels = getAdminUserRoleLabels(adminUser)
+                        const latestDevice = getAdminUserLatestClientDevice(adminUser)
                         return (
                           <tr key={adminUser.id} className="align-top">
                             <td className="px-4 py-3">
@@ -2977,6 +3263,16 @@ export default function AdminPage() {
                               )}
                             </td>
                             <td className="px-4 py-3">
+                              <Badge variant={latestDevice?.legacy_inferred ? "destructive" : latestDevice ? "secondary" : "outline"}>
+                                {getAdminUserClientVersionSummary(adminUser)}
+                              </Badge>
+                              {latestDevice && (
+                                <p className="mt-1 text-xs text-muted-foreground">
+                                  {latestDevice.platform || "unknown"} · {formatAdminUserDateTime(latestDevice.last_seen_at)}
+                                </p>
+                              )}
+                            </td>
+                            <td className="px-4 py-3">
                               <Badge variant={adminUser.mailing_list_opt_in ? "default" : "outline"}>
                                 {adminUser.mailing_list_opt_in ? "Opted in" : "Not opted in"}
                               </Badge>
@@ -2990,6 +3286,20 @@ export default function AdminPage() {
                               <p className="max-w-[260px] break-all font-mono text-xs text-muted-foreground">
                                 {adminUser.primary_wallet_address || "No primary wallet"}
                               </p>
+                            </td>
+                            <td className="px-4 py-3">
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => {
+                                  setSelectedAdminUser(adminUser)
+                                  setAdminUserModalOpen(true)
+                                }}
+                              >
+                                <Eye className="h-4 w-4" />
+                                View
+                              </Button>
                             </td>
                           </tr>
                         )

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -349,6 +349,8 @@ export default function AdminPage() {
   const [adminUsersCount] = useState<number>(20)
   const [adminUsersSearch, setAdminUsersSearch] = useState<string>(readQueryText("users_search", ""))
   const [adminUsersVersionFilter, setAdminUsersVersionFilter] = useState<string>(readQueryText("users_versions", ""))
+  const [debouncedAdminUsersSearch, setDebouncedAdminUsersSearch] = useState<string>(adminUsersSearch)
+  const [debouncedAdminUsersVersionFilter, setDebouncedAdminUsersVersionFilter] = useState<string>(adminUsersVersionFilter)
   const [adminUsersVersionOptions, setAdminUsersVersionOptions] = useState<string[]>([])
   const [adminUsersVersionCounts, setAdminUsersVersionCounts] = useState<ClientVersionUserCountResponse[]>([])
   const [adminUsersLoading, setAdminUsersLoading] = useState<boolean>(false)
@@ -1787,6 +1789,15 @@ export default function AdminPage() {
   useEffect(() => { getAdminWorkflows(adminWorkflowsSearch, adminWorkflowsPage, adminWorkflowsIncludeArchived) }, [adminWorkflowsSearch, adminWorkflowsPage, adminWorkflowsIncludeArchived])
 
   useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedAdminUsersSearch(adminUsersSearch)
+      setDebouncedAdminUsersVersionFilter(adminUsersVersionFilter)
+    }, 300)
+
+    return () => window.clearTimeout(timeout)
+  }, [adminUsersSearch, adminUsersVersionFilter])
+
+  useEffect(() => {
     if (status !== "authenticated") return
 
     switch (activeTab) {
@@ -1794,7 +1805,7 @@ export default function AdminPage() {
         void getAuthedMapLocations()
         break
       case "users":
-        void getAdminUsers(adminUsersPage)
+        void getAdminUsers(adminUsersPage, debouncedAdminUsersSearch, debouncedAdminUsersVersionFilter)
         break
       case "events":
         void getUnallocatedBalance()
@@ -1831,8 +1842,8 @@ export default function AdminPage() {
     activeTab,
     status,
     adminUsersPage,
-    adminUsersSearch,
-    adminUsersVersionFilter,
+    debouncedAdminUsersSearch,
+    debouncedAdminUsersVersionFilter,
     affiliateSearch,
     affiliatePage,
     proposerSearch,

--- a/frontend/types/server.ts
+++ b/frontend/types/server.ts
@@ -6,6 +6,28 @@ import { Improver } from "./improver";
 import { IssuerRecord } from "./issuer";
 import { Supervisor } from "./supervisor";
 
+export interface ClientVersionDeviceResponse {
+  id: number;
+  user_id?: string;
+  platform: string;
+  version: string;
+  build: string;
+  version_label: string;
+  source: string;
+  legacy_inferred: boolean;
+  first_seen_at: string;
+  last_seen_at: string;
+}
+
+export interface ClientVersionUserCountResponse {
+  version_label: string;
+  version: string;
+  build: string;
+  user_count: number;
+  legacy_inferred: boolean;
+  unknown: boolean;
+}
+
 export interface UserResponse {
   id: string;
   is_admin: boolean;
@@ -29,6 +51,7 @@ export interface UserResponse {
   mailing_list_opt_in: boolean;
   mailing_list_opt_in_at?: string | null;
   mailing_list_policy_version: string;
+  client_devices?: ClientVersionDeviceResponse[];
 }
 
 export interface UserPolicyStatusResponse {


### PR DESCRIPTION
## Summary
- record already-shipped mobile client version headers on authenticated/user bootstrap requests
- block likely legacy mobile `GET /users` requests with an update-required message, guarded by `CLIENT_VERSION_LEGACY_BLOCK_ENABLED`
- expose per-user app version observations plus aggregate latest-version user counts in the admin Users tab
- align admin version filters and filter options with the same latest-observation-per-active-user model used by the aggregate buckets

## Notes
- This is backend/admin only. It does not require another mobile app release.
- Migration `1.14` is intentionally included because this branch rolls in the older historical analytics faucet-wallet seed/backfill work before adding `1.15` for client versions.
- Counts and version filters are unique active users grouped by latest recorded app version; the user modal still shows recorded client-version observation history.
- Exact physical device identity is not inferred because the already-released app does not send a stable install ID.
- `user_client_versions.user_id` is intentionally not FK-constrained so authenticated observations can be recorded before first-time `POST /users` bootstrap creates the user row.

## Rollout confirmations
- The released header-sending mobile build attaches `X-SFLUV-Client-Platform`, `X-SFLUV-Client-Version`, and `X-SFLUV-Client-Build` in `rawAuthFetch`, and `GET /users` goes through that path.
- The legacy `1.0.0` app reads failed `/users` responses with `response.text()`, so the plain-text 426 body should be visible in its existing post-login bootstrap error path.
- The legacy block can be disabled by setting `CLIENT_VERSION_LEGACY_BLOCK_ENABLED=false` if the heuristic causes unexpected production traffic impact.

## Validation
- `go test -vet=off ./bootstrap ./db ./handlers ./router ./structs` from `backend/`
- `go test -vet=off ./test -run 'TestApp/user_controllers_group'` from `backend/`
- `git diff --check`
- `./node_modules/.bin/tsc --noEmit --pretty false` from `frontend/` still fails on existing merchant-management/mock data type errors outside the touched admin page
- Full `go test -vet=off ./test` still fails on existing unrelated location/contact/wallet handler test issues
