### PR TITLE
Stop chain-id backfill from blocking/crashing backend boot

### DIFF
--- a/backend/bootstrap/schema_migrations.go
+++ b/backend/bootstrap/schema_migrations.go
@@ -747,15 +747,18 @@ var schemaMigrations = []SchemaMigration{
 		Description: "backfill legacy Berachain chain ids on Ponder transaction tables",
 		Apply: func(ctx context.Context, pools *DBPools, appLogger *logger.LogCloser) error {
 			if pools == nil || pools.Ponder == nil {
-				return fmt.Errorf("ponder db pool is required for the ponder chain-id backfill migration")
+				if appLogger != nil {
+					appLogger.Logf("migration 1.18: ponder pool unavailable, skipping chain-id backfill (runs on server boot)")
+				}
+				return nil
 			}
-			// transfer_event/transfer_account/allowance/approval_event rows with
-			// a NULL chain_id (added by the boot backfill but never populated)
-			// 500 the chain-aware transaction reads. Tag them with the Berachain
-			// id; idempotent (WHERE chain_id IS NULL), runs once.
+			// Non-fatal: a Ponder backfill failure (e.g. lock contention with the
+			// live indexer) must never crash the API boot and take /config down.
+			// The boot-time backfill retries idempotently and reads tolerate a
+			// NULL chain_id, so it is safe to continue.
 			ponderDb := db.Ponder(pools.Ponder, appLogger)
-			if err := ponderDb.BackfillTransactionChainIDs(ctx, legacyBerachainChainID); err != nil {
-				return fmt.Errorf("backfilling ponder transaction chain ids: %w", err)
+			if err := ponderDb.BackfillTransactionChainIDs(ctx, legacyBerachainChainID); err != nil && appLogger != nil {
+				appLogger.Logf("migration 1.18: ponder chain-id backfill failed (non-fatal): %v", err)
 			}
 			return nil
 		},

--- a/backend/cmd/init/main.go
+++ b/backend/cmd/init/main.go
@@ -12,10 +12,7 @@ func main() {
 	bootstrap.LoadEnv()
 	ctx := context.Background()
 
-	// Include the Ponder pool so migrations that backfill Ponder tables (e.g.
-	// the chain-id backfill) have it available; without it those migrations
-	// would be marked complete here without running.
-	pools, err := bootstrap.OpenDBPools(true)
+	pools, err := bootstrap.OpenDBPools(false)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/backend/db/ponder_analytics.go
+++ b/backend/db/ponder_analytics.go
@@ -12,7 +12,7 @@ func (p *PonderDB) GetAnalyticsTransfersSince(ctx context.Context, _ int64, star
 	rows, err := p.db.Query(ctx, `
 			SELECT
 				hash,
-				chain_id,
+				COALESCE(chain_id, 80094) AS chain_id,
 				amount::text,
 				timestamp,
 				LOWER("from"),

--- a/backend/db/ponder_transactions.go
+++ b/backend/db/ponder_transactions.go
@@ -36,7 +36,7 @@ func (p *PonderDB) GetTransactionsPaginated(ctx context.Context, address string,
 	rows, err := p.db.Query(ctx, fmt.Sprintf(`
 			SELECT
 				t.id,
-				t.chain_id,
+				COALESCE(t.chain_id, 80094) AS chain_id,
 				t.hash,
 				t.amount,
 				t.timestamp,
@@ -127,7 +127,7 @@ func (p *PonderDB) GetTransactionPartiesByHash(ctx context.Context, txHash strin
 
 	row := p.db.QueryRow(ctx, `
 			SELECT
-				t.chain_id,
+				COALESCE(t.chain_id, 80094) AS chain_id,
 				t.hash,
 				t.from,
 				t.to
@@ -136,7 +136,7 @@ func (p *PonderDB) GetTransactionPartiesByHash(ctx context.Context, txHash strin
 			WHERE
 				t.hash = LOWER($1)
 			AND
-				($2::BIGINT <= 0 OR t.chain_id = $2)
+				($2::BIGINT <= 0 OR COALESCE(t.chain_id, 80094) = $2)
 			ORDER BY
 				t.timestamp DESC,
 				t.id DESC

--- a/backend/db/transaction_chain_tags.go
+++ b/backend/db/transaction_chain_tags.go
@@ -103,6 +103,25 @@ func (p *PonderDB) BackfillTransactionChainIDs(ctx context.Context, chainID int6
 		},
 	}
 
+	// Run on a single dedicated connection with bounded lock/statement timeouts.
+	// The live indexer continuously writes these tables, so an ALTER (ACCESS
+	// EXCLUSIVE) or bulk UPDATE that can't get its lock must fail fast rather
+	// than block — otherwise it hangs the boot path before the HTTP server
+	// starts listening, the platform's health check kills the unready process,
+	// and the backend crash-loops with no logged error. Callers treat failures
+	// as non-fatal and retry on the next boot.
+	conn, err := p.db.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("acquiring ponder connection for chain-id backfill: %w", err)
+	}
+	defer conn.Release()
+	if _, err := conn.Exec(ctx, `SET lock_timeout = '3s'`); err != nil {
+		return fmt.Errorf("setting lock_timeout: %w", err)
+	}
+	if _, err := conn.Exec(ctx, `SET statement_timeout = '120s'`); err != nil {
+		return fmt.Errorf("setting statement_timeout: %w", err)
+	}
+
 	for _, table := range tables {
 		exists, err := p.tableExists(ctx, table.name)
 		if err != nil {
@@ -112,26 +131,38 @@ func (p *PonderDB) BackfillTransactionChainIDs(ctx context.Context, chainID int6
 			continue
 		}
 
-		if _, err := p.db.Exec(ctx, fmt.Sprintf(`ALTER TABLE %s ADD COLUMN IF NOT EXISTS chain_id BIGINT`, table.name)); err != nil {
+		if _, err := conn.Exec(ctx, fmt.Sprintf(`ALTER TABLE %s ADD COLUMN IF NOT EXISTS chain_id BIGINT`, table.name)); err != nil {
 			return fmt.Errorf("error backfilling ponder table %s chain ids (alter): %w", table.name, err)
 		}
-		// Set the default first so every row the indexer inserts from here on is
-		// tagged (the current single-chain indexer does not write chain_id), which
-		// also prevents a new NULL from racing the SET NOT NULL below. chainID is a
-		// trusted int64, so inlining it in the DDL is safe. The default is changed
-		// in a later migration at the Celo cutover.
-		if _, err := p.db.Exec(ctx, fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN chain_id SET DEFAULT %d`, table.name, chainID)); err != nil {
+		// Set the default (instant, metadata-only) so every row the indexer
+		// inserts from here on is tagged — the current single-chain indexer does
+		// not write chain_id. chainID is a trusted int64, safe to inline in DDL.
+		// The default is changed by a later migration at the Celo cutover.
+		//
+		// NOT NULL is intentionally NOT enforced: SET NOT NULL requires a full
+		// validate scan + ACCESS EXCLUSIVE lock that, on a large actively-written
+		// table, blocks indefinitely. Reads tolerate a NULL chain_id (treated as
+		// the active chain), so the default + best-effort backfill are enough.
+		if _, err := conn.Exec(ctx, fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN chain_id SET DEFAULT %d`, table.name, chainID)); err != nil {
 			return fmt.Errorf("error backfilling ponder table %s chain ids (set default): %w", table.name, err)
 		}
-		if _, err := p.db.Exec(ctx, fmt.Sprintf(`UPDATE %s SET chain_id = $1 WHERE chain_id IS NULL`, table.name), chainID); err != nil {
-			return fmt.Errorf("error backfilling ponder table %s chain ids (update): %w", table.name, err)
-		}
-		if _, err := p.db.Exec(ctx, fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN chain_id SET NOT NULL`, table.name)); err != nil {
-			return fmt.Errorf("error backfilling ponder table %s chain ids (set not null): %w", table.name, err)
+		// Backfill existing NULLs in bounded batches: a single UPDATE over a large
+		// live table takes a long lock and can hit statement_timeout. The default
+		// above stops new NULLs, so this converges.
+		for {
+			tag, err := conn.Exec(ctx, fmt.Sprintf(
+				`UPDATE %s SET chain_id = $1 WHERE ctid IN (SELECT ctid FROM %s WHERE chain_id IS NULL LIMIT 5000)`,
+				table.name, table.name), chainID)
+			if err != nil {
+				return fmt.Errorf("error backfilling ponder table %s chain ids (update): %w", table.name, err)
+			}
+			if tag.RowsAffected() == 0 {
+				break
+			}
 		}
 
 		for _, indexQuery := range table.indexes {
-			if _, err := p.db.Exec(ctx, indexQuery); err != nil {
+			if _, err := conn.Exec(ctx, indexQuery); err != nil {
 				return fmt.Errorf("error creating chain index for ponder table %s: %w", table.name, err)
 			}
 		}


### PR DESCRIPTION
The backfill ran ALTER (ACCESS EXCLUSIVE) and a full-table UPDATE on the live, indexer-written Ponder tables. Those block on lock acquisition, so the migration hung before the HTTP server started listening, the health check killed the unready process, and the backend crash-looped with no logged error.

- Run the backfill on a dedicated connection with lock_timeout=3s and statement_timeout=120s so contended statements fail fast instead of hanging.
- Drop SET NOT NULL (full validate scan + ACCESS EXCLUSIVE); the column DEFAULT already tags new rows. Backfill existing NULLs in 5k-row batches.
- Make migration 1.18 non-fatal and skip cleanly without a Ponder pool; revert cmd/init to not require Ponder.
- Make transaction/analytics reads NULL-tolerant (COALESCE chain_id -> 80094) so history works regardless of backfill state.