### PR TITLE
Use backend RPC for client reads; keep engine for the bundler

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -46,6 +46,11 @@ UNDERLYING_TOKEN_ID=x
 # Legacy backend token multiplier used for payouts, W9 limits, and formatting.
 # /config derives ERC-20 decimal places from this value for the mobile app.
 TOKEN_DECIMALS=1000000000000000000
+# Full JSON-RPC node URL. Also served to clients as /config.extras.rpc_url and
+# used by web/mobile for READS (eth_getCode/eth_getBalance/eth_getStorageAt),
+# which the Citizen Wallet engine does not support. The AA bundler/paymaster
+# still uses the engine (chains[].node.url/v1/rpc/{paymaster}). Must be a real
+# node, not the engine. CLIENT_READ_RPC_URL overrides this for the served value.
 RPC_URL=x
 
 # Chain-specific extras that Citizen Wallet config does not model yet. These are

--- a/backend/clientconfig/config.go
+++ b/backend/clientconfig/config.go
@@ -72,6 +72,12 @@ type Extras struct {
 	ZapperAddress     string   `json:"zapper_address,omitempty"`
 	FaucetAddress     string   `json:"faucet_address,omitempty"`
 	BackingAssets     []string `json:"backing_assets,omitempty"`
+	// ReadRPCURL is a full JSON-RPC node URL for general reads (eth_getCode,
+	// eth_getBalance, eth_getStorageAt, ...). The Citizen Wallet engine at
+	// chains[].node.url is a curated RPC that 404s those methods, so clients
+	// must use this for reads and reserve the engine for the AA bundler. Sourced
+	// from the backend RPC_URL env, taking precedence over the engine URL.
+	ReadRPCURL string `json:"rpc_url,omitempty"`
 }
 
 type Config struct {
@@ -461,6 +467,9 @@ func loadEnvironmentExtras() (Extras, error) {
 	if extras.BackingAssets, err = envAddressList("BACKING_ASSETS", "NEXT_PUBLIC_BACKING_ASSETS"); err != nil {
 		return Extras{}, err
 	}
+	if extras.ReadRPCURL, err = envURL("CLIENT_READ_RPC_URL", "RPC_URL", "NEXT_PUBLIC_RPC_URL"); err != nil {
+		return Extras{}, err
+	}
 
 	return extras, nil
 }
@@ -486,6 +495,9 @@ func mergeExtras(base, override Extras) Extras {
 	}
 	if len(override.BackingAssets) > 0 {
 		base.BackingAssets = override.BackingAssets
+	}
+	if override.ReadRPCURL != "" {
+		base.ReadRPCURL = override.ReadRPCURL
 	}
 	return base
 }
@@ -519,7 +531,8 @@ func (e Extras) isZero() bool {
 		e.ByusdDecimals == nil &&
 		e.ZapperAddress == "" &&
 		e.FaucetAddress == "" &&
-		len(e.BackingAssets) == 0
+		len(e.BackingAssets) == 0 &&
+		e.ReadRPCURL == ""
 }
 
 func responseJSON(body []byte, extras Extras) ([]byte, error) {
@@ -545,6 +558,7 @@ func responseJSON(body []byte, extras Extras) ([]byte, error) {
 	writeIntExtra(extrasDoc, "byusd_decimals", extras.ByusdDecimals)
 	writeStringExtra(extrasDoc, "zapper_address", extras.ZapperAddress)
 	writeStringExtra(extrasDoc, "faucet_address", extras.FaucetAddress)
+	writeStringExtra(extrasDoc, "rpc_url", extras.ReadRPCURL)
 	writeStringSliceExtra(extrasDoc, "backing_assets", extras.BackingAssets)
 
 	if len(extrasDoc) == 0 {
@@ -581,6 +595,8 @@ func deleteKnownExtraFields(doc map[string]json.RawMessage) {
 		"faucetAddress",
 		"backing_assets",
 		"backingAssets",
+		"rpc_url",
+		"rpcUrl",
 	} {
 		delete(doc, key)
 	}
@@ -608,6 +624,17 @@ func writeStringSliceExtra(doc map[string]json.RawMessage, key string, value []s
 	}
 	raw, _ := json.Marshal(value)
 	doc[key] = raw
+}
+
+func envURL(names ...string) (string, error) {
+	name, value := firstEnv(names...)
+	if value == "" {
+		return "", nil
+	}
+	if _, err := url.ParseRequestURI(value); err != nil {
+		return "", fmt.Errorf("%s must be a valid URL: %w", name, err)
+	}
+	return value, nil
 }
 
 func envAddress(names ...string) (string, error) {

--- a/frontend/lib/community-config.ts
+++ b/frontend/lib/community-config.ts
@@ -95,6 +95,7 @@ export type ResolvedCommunityConfig = {
   chain: Chain
   chainId: number
   rpcUrl: string
+  bundlerRpcUrl: string
   engineWsUrl?: string
   tokenAddress: Address
   tokenDecimals: number
@@ -141,10 +142,13 @@ export function resolveCommunityConfig(payload: CommunityConfigPayload): Resolve
   }
 
   const community = new CommunityConfig(payload as any)
-  // The Citizen Wallet engine serves JSON-RPC (and AA methods) at
-  // `${node.url}/v1/rpc/${paymaster}`, not at the bare node.url. Posting to the
-  // root returns 401, so use the SDK's canonical RPC URL for all transports.
-  const rpcUrl = community.primaryRPCUrl
+  // The CW engine serves the AA bundler/paymaster methods at
+  // `${node.url}/v1/rpc/${paymaster}` — used for sponsorship + sending only.
+  const bundlerRpcUrl = community.primaryRPCUrl
+  // Reads (eth_getCode/eth_getBalance/eth_getStorageAt) must use a full node
+  // RPC: the engine 404s those methods. Prefer the backend-provided rpc_url
+  // (RPC_URL env), falling back to the engine only if none is configured.
+  const rpcUrl = findExtraString(payload.extras, "rpc_url", "rpcUrl") || bundlerRpcUrl
 
   const baseChain = knownChains[primaryTokenRef.chain_id] ?? {
     id: primaryTokenRef.chain_id,
@@ -184,6 +188,7 @@ export function resolveCommunityConfig(payload: CommunityConfigPayload): Resolve
     chain,
     chainId: primaryTokenRef.chain_id,
     rpcUrl,
+    bundlerRpcUrl,
     engineWsUrl: chainConfig?.node?.ws_url,
     tokenAddress: token.address as Address,
     tokenDecimals: token.decimals,
@@ -265,6 +270,17 @@ function findExtraAddress(
   for (const key of keys) {
     const address = readAddressish(extras?.[key])
     if (address) return address
+  }
+  return undefined
+}
+
+function findExtraString(
+  extras: CommunityConfigPayload["extras"] | undefined,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = extras?.[key]
+    if (typeof value === "string" && value.trim() !== "") return value.trim()
   }
   return undefined
 }

--- a/frontend/lib/paymaster/client.ts
+++ b/frontend/lib/paymaster/client.ts
@@ -6,7 +6,8 @@ import type { ResolvedCommunityConfig } from "@/lib/community-config";
 export function createViemClients(config: ResolvedCommunityConfig) {
   const bundler = createBundlerClient({
     chain: config.chain,
-    transport: http(config.rpcUrl, {
+    // AA bundler/paymaster methods are served only by the CW engine.
+    transport: http(config.bundlerRpcUrl, {
       methods: {
         include: ["pm_sponsorUserOperation", "eth_sendUserOperation"]
       }
@@ -15,6 +16,8 @@ export function createViemClients(config: ResolvedCommunityConfig) {
 
   const cw_bundler = new BundlerService(config.community)
 
+  // Reads (eth_getCode/eth_getBalance/...) use a full node RPC; the engine 404s
+  // those methods.
   const client = createPublicClient({
     chain: config.chain,
     transport: http(config.rpcUrl)


### PR DESCRIPTION
The Citizen Wallet engine (chains[].node.url/v1/rpc/{paymaster}) only serves a curated method set and 404s eth_getCode/eth_getBalance/eth_getStorageAt, which broke web login (smart-wallet deployment check). A full node RPC is required for reads, but the CW BundlerService derives its AA URL from node.url, so the engine must stay there for sends/sponsorship.

- Backend serves the env RPC (RPC_URL, or CLIENT_READ_RPC_URL) as /config.extras.rpc_url, taking precedence for client reads.
- Web/mobile use that rpc_url for the public client / ethers provider; the bundler/paymaster keeps using the engine URL.