### PR TITLE
[codex] Add Google place text search fallback

### DIFF
--- a/frontend/components/merchant/google_place_finder.tsx
+++ b/frontend/components/merchant/google_place_finder.tsx
@@ -1,8 +1,7 @@
 "use client"; // for Next.js App Router
 
 import { useEffect, useRef, useState } from "react";
-import { LAT_DIF, LNG_DIF, MAP_CENTER, MAP_RADIUS } from "@/lib/constants";
-import { useApp } from "@/context/AppProvider";
+import { LAT_DIF, LNG_DIF, MAP_CENTER } from "@/lib/constants";
 import { GoogleSubLocation } from "@/types/location";
 
 interface PlaceAutocompleteProps {
@@ -14,6 +13,97 @@ interface PlaceAutocompleteProps {
 
 export default function PlaceAutocomplete({ setGoogleSubLocation, setBusinessPhone, setStreet, onSelect}: PlaceAutocompleteProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [textSearch, setTextSearch] = useState("");
+  const [textSearchBusy, setTextSearchBusy] = useState(false);
+  const [textSearchError, setTextSearchError] = useState("");
+
+  const locationRestriction = {
+      south: MAP_CENTER.lat - LAT_DIF,
+      west: MAP_CENTER.lng - LNG_DIF,
+      north: MAP_CENTER.lat + LAT_DIF,
+      east: MAP_CENTER.lng + LNG_DIF,
+  };
+
+  const fields = [
+      'id', 'displayName', 'addressComponents', 'location', 'rating', 'regularOpeningHours',
+      'websiteURI', 'primaryTypeDisplayName', 'nationalPhoneNumber', 'googleMapsURI', 'photos',
+      'svgIconMaskURI'
+  ];
+
+  const addressPart = (rawGoogleData: any, type: string) => {
+      return rawGoogleData.addressComponents?.find((part: any) => part.types?.includes(type))?.longText || "";
+  };
+
+  const applyPlace = (rawGoogleData: any) => {
+      const lat = rawGoogleData.location?.lat ?? rawGoogleData.location?.latitude;
+      const lng = rawGoogleData.location?.lng ?? rawGoogleData.location?.longitude;
+      if (!rawGoogleData.id || typeof lat !== "number" || typeof lng !== "number") {
+          setTextSearchError("Google returned this place without a place ID or coordinates. Try another search.");
+          return;
+      }
+      setTextSearchError("");
+      const street = [addressPart(rawGoogleData, "street_number"), addressPart(rawGoogleData, "route")]
+          .filter(Boolean)
+          .join(" ");
+      const displayName = typeof rawGoogleData.displayName === "string" ? rawGoogleData.displayName : rawGoogleData.displayName?.text || "";
+      const primaryType = typeof rawGoogleData.primaryTypeDisplayName === "string" ? rawGoogleData.primaryTypeDisplayName : rawGoogleData.primaryTypeDisplayName?.text || "";
+      const googleDetails: GoogleSubLocation = {
+          google_id: rawGoogleData.id,
+          name: displayName,
+          type: primaryType,
+          street,
+          city: addressPart(rawGoogleData, "locality"),
+          state: addressPart(rawGoogleData, "administrative_area_level_1"),
+          zip: addressPart(rawGoogleData, "postal_code"),
+          lat,
+          lng,
+          phone: rawGoogleData.nationalPhoneNumber,
+          website: rawGoogleData.websiteURI,
+          image_url: rawGoogleData.photos?.[0]?.googleMapsURI || "",
+          rating: rawGoogleData.rating,
+          maps_page: rawGoogleData.googleMapsURI,
+          opening_hours: rawGoogleData.regularOpeningHours?.weekdayDescriptions || [],
+      }
+      setGoogleSubLocation(googleDetails)
+      onSelect?.(googleDetails)
+      if (typeof googleDetails.phone === "string") {
+      setBusinessPhone(googleDetails.phone)
+      } else {
+        setBusinessPhone("")
+      }
+      if (typeof googleDetails.street === "string") {
+      setStreet(googleDetails.street)
+      } else {
+        setStreet("")
+      }
+  };
+
+  const searchByText = async () => {
+      const query = textSearch.trim();
+      if (!query) return;
+
+      setTextSearchBusy(true);
+      setTextSearchError("");
+      try {
+          const { Place } = await google.maps.importLibrary("places") as google.maps.PlacesLibrary;
+          const { places } = await Place.searchByText({
+              textQuery: query,
+              fields,
+              locationRestriction,
+              maxResultCount: 1,
+          } as any);
+          if (!places?.length) {
+              setTextSearchError("No Google place found. Try the name plus city or street address.");
+              return;
+          }
+          applyPlace(places[0].toJSON());
+      } catch (error) {
+          console.error(error);
+          setTextSearchError("Unable to search Google Places right now.");
+      } finally {
+          setTextSearchBusy(false);
+      }
+  };
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -26,53 +116,14 @@ export default function PlaceAutocomplete({ setGoogleSubLocation, setBusinessPho
     await importGoogleLibrary()
     //@ts-ignore
     const placeAutocomplete = new google.maps.places.PlaceAutocompleteElement({
-    locationRestriction: {
-        south: MAP_CENTER.lat - LAT_DIF,
-        west: MAP_CENTER.lng - LNG_DIF,
-        north: MAP_CENTER.lat + LAT_DIF,
-        east: MAP_CENTER.lng + LNG_DIF,},
+    locationRestriction,
     });
 
     //@ts-ignore
     placeAutocomplete.addEventListener('gmp-select', async ({ placePrediction }) => {
         const place = placePrediction.toPlace();
-        await place.fetchFields({ fields: [
-            'displayName', 'addressComponents', 'location', 'rating', 'regularOpeningHours',
-            'websiteURI', 'primaryTypeDisplayName', 'nationalPhoneNumber', 'googleMapsURI', 'photos',
-            'svgIconMaskURI'
-
-
-        ] });
-        const rawGoogleData = place.toJSON()
-        const googleDetails: GoogleSubLocation = {
-            google_id: rawGoogleData.id,
-            name: rawGoogleData.displayName,
-            type: rawGoogleData.primaryTypeDisplayName,
-            street: (rawGoogleData.addressComponents[0]?.longText || "") + " " + (rawGoogleData.addressComponents[1]?.longText || ""),
-            city: rawGoogleData.addressComponents[3]?.longText || "",
-            state: rawGoogleData.addressComponents[5]?.longText || "",
-            zip: rawGoogleData.addressComponents[7]?.longText || "",
-            lat: rawGoogleData.location.lat,
-            lng: rawGoogleData.location.lng,
-            phone: rawGoogleData.nationalPhoneNumber,
-            website: rawGoogleData.websiteURI,
-            image_url: rawGoogleData.photos[0]?.googleMapsURI || "",
-            rating: rawGoogleData.rating,
-            maps_page: rawGoogleData.googleMapsURI,
-            opening_hours: rawGoogleData.regularOpeningHours?.weekdayDescriptions || [],
-        }
-        setGoogleSubLocation(googleDetails)
-        onSelect?.(googleDetails)
-        if (typeof googleDetails.phone === "string") {
-        setBusinessPhone(googleDetails.phone)
-        } else {
-          setBusinessPhone("")
-        }
-        if (typeof googleDetails.street === "string") {
-        setStreet(googleDetails.street)
-        } else {
-          setStreet("")
-        }
+        await place.fetchFields({ fields });
+        applyPlace(place.toJSON())
     });
     placeAutocomplete.className="text-black dark:text-white border rounded-md bg-secondary px-3 py-2"
 
@@ -88,7 +139,34 @@ export default function PlaceAutocomplete({ setGoogleSubLocation, setBusinessPho
 , [])
 
   return (
-      <div ref={containerRef} style={{
-  }}></div>
+      <div className="space-y-2">
+          <div ref={containerRef} style={{
+      }}></div>
+          <div className="flex gap-2">
+              <input
+                  className="min-w-0 flex-1 rounded-md border bg-secondary px-3 py-2 text-sm text-black dark:text-white"
+                  placeholder="Exact name or address"
+                  value={textSearch}
+                  onChange={(event) => setTextSearch(event.target.value)}
+                  onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                          event.preventDefault();
+                          void searchByText();
+                      }
+                  }}
+              />
+              <button
+                  className="rounded-md border px-3 py-2 text-sm text-black disabled:opacity-50 dark:text-white"
+                  disabled={textSearchBusy}
+                  onClick={() => void searchByText()}
+                  type="button"
+              >
+                  {textSearchBusy ? "Searching..." : "Search"}
+              </button>
+          </div>
+          {textSearchError ? (
+              <p className="text-xs text-red-600 dark:text-red-300">{textSearchError}</p>
+          ) : null}
+      </div>
   )
 }


### PR DESCRIPTION
## Summary
- Adds an exact-name/address Text Search fallback beside the existing Google Places autocomplete widget.
- Reuses the same Google place mapping for autocomplete and text search, requiring a place id plus coordinates before filling the merchant form.
- Handles places without photos without crashing the selection flow.

## Why
Autocomplete currently returns no suggestions for `Sheba Clothing and Gifts Store San Francisco`, even though Text Search and Place Details return the listing cleanly.

## Validation
- Verified Google Text Search returns `ChIJbxNd0t-BhYAR8hW9nT4e_eQ` for `Sheba Clothing and Gifts Store San Francisco`.
- Verified Place Details for that id returns `318 Turk St, San Francisco, CA 94102`, `37.783016,-122.414604`, phone, Maps URI, and type.
- Ran `git diff --check`.
- Ran `cd frontend && npx tsc --noEmit --pretty false`; it still fails on existing unrelated merchant/mock type errors, with no errors reported for `components/merchant/google_place_finder.tsx`.

## Notes
`next lint --file components/merchant/google_place_finder.tsx` is not usable yet because Next prompts to configure ESLint for the project.
